### PR TITLE
add delay to eiger

### DIFF
--- a/src/id4_common/startup.py
+++ b/src/id4_common/startup.py
@@ -158,4 +158,4 @@ for sus in shutter_suspenders.values():
     RE.install_suspender(sus)
 
 # TODO: REMOVE THIS AFTER UPSTREAM FIX
-_ = RE.preprocessors.pop()
+# _ = RE.preprocessors.pop()


### PR DESCRIPTION
## Issue

We found that Bluesky was grabbing the stats before it had processed the last image (it was picking the data from the previous point). This comes from the fact that the EPICS support has no good signal that reports the stats as done. Initial tests revealed that it needs a minimum 0.2 s wait (for example if counting 0.1 s it waits 0.2 s, but if counting 0.3 s, it waits 0). While this works as far as not missing any images, it does not take into account the status of the stats plugins.

## Solution

Added an additional `.delay` property that is the time in seconds that it will wait beyond the count time (it will wait for count time + delay). Initial tests indicate that 0.3 seconds is a good number.