### PR TITLE
Update repository to match latest apsbits

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ create-bits $YOUR_INSTRUMENT_NAME
 pip install -e .
 ```
 
+## Setup conda config vars for hklpy
+```bash
+conda env config vars set LD_LIBRARY_PATH="$HOME/.conda/envs/$ENV_NAME/lib:$LD_LIBRARY_PATH"
+```
 
 ## IPython console Start
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Instrument Github Repository to be used with BITS structure at the APS
 
 ```bash
 export ENV_NAME=polar-bits
-conda create -y -n $ENV_NAME python=3.11 hkl pyepics
+conda create -y -n $ENV_NAME python=3.11 hkl pyepics aps-dm-api
 conda activate $ENV_NAME
 pip install apsbits
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,12 @@ classifiers = []
 license = "LicenseRef-ANL-Open-Source-License"
 license-files = ["LICEN[CS]E*"]
 dependencies = [
+    "databroker<2",
     "apsbits",
     "hklpy",
     "hklpy2",
     "polartools",
     "streamz",
-    "aps-dm-api",
 ]
 
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,11 @@ license = "LicenseRef-ANL-Open-Source-License"
 license-files = ["LICEN[CS]E*"]
 dependencies = [
     "apsbits",
+    "hklpy",
     "hklpy2",
     "polartools",
     "streamz",
+    "aps-dm-api",
 ]
 
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = []
 license = "LicenseRef-ANL-Open-Source-License"
 license-files = ["LICEN[CS]E*"]
 dependencies = [
-    "databroker==1.2.5",
     "apsbits",
     "hklpy2",
     "polartools",

--- a/src/id4_b/configs/iconfig_extras.yml
+++ b/src/id4_b/configs/iconfig_extras.yml
@@ -7,14 +7,13 @@ ICONFIG_VERSION: 2.0.0
 STATION: &station 4idb
 
 ### The short name for the databroker catalog.
-DATABROKER_CATALOG: &databroker_catalog 4id_polar
+DATABROKER_CATALOG: 4id_polar
 
 ### RunEngine configuration
 RUN_ENGINE:
     DEFAULT_METADATA:
         beamline_id: 4id-polar
         instrument_name: polar-4idb
-        databroker_catalog: *databroker_catalog
 
     ### EPICS PV to use for the `scan_id`.
     ### Default: `RE.md["scan_id"]` (not using an EPICS PV)

--- a/src/id4_b/startup.py
+++ b/src/id4_b/startup.py
@@ -63,6 +63,7 @@ from id4_common.utils.run_engine import (  # noqa: F401, E402
     sd,
     bec,
     cat,
+    cat_legacy,
     peaks,
 )
 

--- a/src/id4_b/startup.py
+++ b/src/id4_b/startup.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from apsbits.core.instrument_init import make_devices
 from apsbits.core.instrument_init import oregistry
 from apsbits.core.instrument_init import instrument  # noqa: F401
-from apsbits.utils.aps_functions import aps_dm_setup  # TODO: is this correct?
+from id4_common.utils.aps_functions import aps_dm_setup
 from apsbits.utils.config_loaders import get_config
 from apsbits.utils.config_loaders import load_config
 from apsbits.utils.config_loaders import load_config_yaml
@@ -63,7 +63,7 @@ from id4_common.utils.run_engine import (  # noqa: F401, E402
     RE,
     sd,
     bec,
-    cat as full_cat,  # This is the whole beamline catalog, below we narrow it.
+    cat,
     peaks,
 )
 
@@ -145,7 +145,7 @@ else:
     from id4_common.plans import *  # noqa: F401, F403
 
 logger.info("Loading 4-ID-B devices, this can take a few minutes.")
-RE(make_devices(clear=True, file="devices.yml"))  # Create the devices.
+make_devices(clear=True, file="devices.yml", device_manager=instrument)
 stations = ["core", "4idb"]
 for device in oregistry.findall(stations):
     connect_device(device, raise_error=False)
@@ -154,10 +154,3 @@ counters.plotselect(11, 0)
 
 for sus in shutter_suspenders.values():
     RE.install_suspender(sus)
-
-# Use a subset of the catalog - just for this station
-# This helps sorting up if there is a mix up of the scan_ids when using
-# two stations at the same time.
-cat = db_query(  # noqa: F405
-    full_cat, dict(instrument_name=f'polar-{iconfig["STATION"]}')
-)

--- a/src/id4_b/startup.py
+++ b/src/id4_b/startup.py
@@ -12,9 +12,8 @@ Includes:
 import logging
 from pathlib import Path
 
+from apsbits.core.instrument_init import init_instrument
 from apsbits.core.instrument_init import make_devices
-from apsbits.core.instrument_init import oregistry
-from apsbits.core.instrument_init import instrument  # noqa: F401
 from id4_common.utils.aps_functions import aps_dm_setup
 from apsbits.utils.config_loaders import get_config
 from apsbits.utils.config_loaders import load_config
@@ -45,7 +44,7 @@ iconfig = get_config()
 
 logger.info("Starting Instrument with iconfig: %s", iconfig_path)
 
-# Discard oregistry items loaded above.
+instrument, oregistry = init_instrument("guarneri")
 oregistry.clear()
 
 # Configure the session with callbacks, devices, and plans.

--- a/src/id4_common/configs/iconfig.yml
+++ b/src/id4_common/configs/iconfig.yml
@@ -7,7 +7,9 @@ ICONFIG_VERSION: 2.0.1
 STATION: &station dev
 
 ### The short name for the databroker catalog.
-DATABROKER_CATALOG: &databroker_catalog 4id_polar
+DATABROKER_CATALOG: 4id_polar
+TILED_PROFILE_NAME: 4id_polar
+TILED_PATH_NAME: /raw
 
 ### RunEngine configuration
 RUN_ENGINE:
@@ -15,7 +17,6 @@ RUN_ENGINE:
         beamline_id: 4id-polar
         instrument_name: polar-dev
         proposal_id: commissioning
-        databroker_catalog: *databroker_catalog
 
     ### EPICS PV to use for the `scan_id`.
     ### Default: `RE.md["scan_id"]` (not using an EPICS PV)

--- a/src/id4_common/configs/iconfig.yml
+++ b/src/id4_common/configs/iconfig.yml
@@ -8,7 +8,7 @@ STATION: &station dev
 
 ### The short name for the databroker catalog.
 DATABROKER_CATALOG: 4id_polar
-TILED_PROFILE_NAME: 4id_polar
+TILED_PROFILE_NAME: raw
 TILED_PATH_NAME: /raw
 
 ### RunEngine configuration

--- a/src/id4_common/configs/iconfig.yml
+++ b/src/id4_common/configs/iconfig.yml
@@ -8,8 +8,12 @@ STATION: &station dev
 
 ### The short name for the databroker catalog.
 DATABROKER_CATALOG: 4id_polar
-TILED_PROFILE_NAME: raw
-TILED_PATH_NAME: /raw
+
+# TODO: We will stay with MongoDB for now until there is more clarity on the
+# APS data management plans. Tiled is also < 1.
+# TILED_PROFILE_NAME: raw
+# TILED_PATH_NAME: /raw
+# DATABROKER_CATALOG: MongoDB
 
 ### RunEngine configuration
 RUN_ENGINE:

--- a/src/id4_common/devices/magnet_911.py
+++ b/src/id4_common/devices/magnet_911.py
@@ -137,7 +137,9 @@ class PowerSupply(Device):
 
 
 class MonChannel(Device):
-    temperature_name = FormattedComponent(EpicsSignalRO, "{prefix}TempName{ch}")
+    temperature_name = FormattedComponent(
+        EpicsSignalRO, "{prefix}TempName{ch}", string=True
+    )
     temperature = FormattedComponent(EpicsSignalRO, "{prefix}Temp{ch}")
     hall_resistance = FormattedComponent(EpicsSignalRO, "{prefix}HallRes{ch}")
     hall_field = FormattedComponent(EpicsSignalRO, "{prefix}HallField{ch}")

--- a/src/id4_common/startup.py
+++ b/src/id4_common/startup.py
@@ -50,7 +50,7 @@ from .utils.local_magics import LocalMagics  # noqa: E402
 get_ipython().register_magics(LocalMagics)
 
 # Initialize core bluesky components
-from .utils.run_engine import RE, sd, bec, cat, peaks  # noqa: F401, E402
+from .utils.run_engine import RE, sd, bec, cat, cat_legacy, peaks  # noqa: F401, E402
 
 # Import optional components based on configuration
 if iconfig.get("NEXUS_DATA_FILES", {}).get("ENABLE", False):

--- a/src/id4_common/startup.py
+++ b/src/id4_common/startup.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from apsbits.core.instrument_init import make_devices
 from apsbits.core.instrument_init import oregistry
 from apsbits.core.instrument_init import instrument  # noqa: F401
-from apsbits.utils.aps_functions import aps_dm_setup  # TODO: is this correct?
+from id4_common.utils.aps_functions import aps_dm_setup
 from apsbits.utils.config_loaders import get_config
 from apsbits.utils.config_loaders import load_config
 from apsbits.utils.helper_functions import register_bluesky_magics
@@ -134,7 +134,7 @@ try:
     if _load_devices.lower() in ["y", "yes"]:
         logger.info("Loading all devices, this can take a few minutes.")
 
-        RE(make_devices(clear=True, file="devices.yml"))  # Create the devices.
+        make_devices(clear=True, file="devices.yml", device_manager=instrument)
         stations = ["core", "4idb", "4idg", "4idh"]
         for device in oregistry.findall(stations):
             connect_device(device, raise_error=False)

--- a/src/id4_common/startup.py
+++ b/src/id4_common/startup.py
@@ -12,9 +12,8 @@ Includes:
 import logging
 from pathlib import Path
 
+from apsbits.core.instrument_init import init_instrument
 from apsbits.core.instrument_init import make_devices
-from apsbits.core.instrument_init import oregistry
-from apsbits.core.instrument_init import instrument  # noqa: F401
 from id4_common.utils.aps_functions import aps_dm_setup
 from apsbits.utils.config_loaders import get_config
 from apsbits.utils.config_loaders import load_config
@@ -37,7 +36,7 @@ iconfig = get_config()
 
 logger.info("Starting Instrument with iconfig: %s", iconfig_path)
 
-# Discard oregistry items loaded above.
+instrument, oregistry = init_instrument("guarneri")
 oregistry.clear()
 
 # Configure the session with callbacks, devices, and plans.

--- a/src/id4_common/utils/aps_functions.py
+++ b/src/id4_common/utils/aps_functions.py
@@ -1,0 +1,58 @@
+"""
+APS utility helper functions.
+=============================
+
+``aps_dm_setup`` was removed from apsbits in 2.0+. It is vendored here
+as a temporary measure until it can be properly integrated into apstools
+(see apstools issue #1147).
+
+.. autosummary::
+
+    ~aps_dm_setup
+"""
+
+import logging
+import os
+import pathlib
+
+logger = logging.getLogger(__name__)
+
+
+def aps_dm_setup(dm_setup_file_path):
+    """
+    APS Data Management setup.
+
+    Read the bash shell script file used by DM to setup the environment.
+    Parse any ``export`` lines and add their environment variables to this
+    session. This is done by brute force here since the APS DM environment
+    setup requires different Python code than bluesky and the two often clash.
+
+    This setup must be done before any of the DM package libraries are called.
+    """
+    if dm_setup_file_path is not None:
+        bash_script = pathlib.Path(dm_setup_file_path)
+        if bash_script.exists():
+            logger.info("APS DM environment file: %s", str(bash_script))
+            environment = {}
+            for line in open(bash_script).readlines():
+                if not line.startswith("export "):
+                    continue
+                export_part = line.strip().split("export ", 1)[-1]
+                if not export_part:
+                    continue
+                if "=" in export_part:
+                    k, v = export_part.split("=", 1)
+                    k = k.strip()
+                    v = v.strip()
+                else:
+                    k = export_part.strip()
+                    v = ""
+                environment[k] = v
+            os.environ.update(environment)
+
+            workflow_owner = os.environ.get("DM_STATION_NAME", "").lower()
+            logger.info("APS DM workflow owner: %s", workflow_owner)
+        else:
+            logger.warning(
+                "APS DM setup file does not exist: '%s'", bash_script
+            )

--- a/src/id4_common/utils/run_engine.py
+++ b/src/id4_common/utils/run_engine.py
@@ -13,9 +13,15 @@ from apsbits.core.run_engine_init import init_RE
 from apsbits.core.best_effort_init import init_bec_peaks
 from apsbits.utils.config_loaders import get_config
 from apsbits.core.catalog_init import init_catalog
+# from tiled.client import from_profile
 
 iconfig = get_config()
 cat = init_catalog(iconfig)
+cat_legacy = None
+# TODO: This is a placeholder for when we switch to tiled.
+# cat_legacy = from_profile(iconfig.get("TILED_PROFILE_NAME"))[
+#     iconfig.get("DATABROKER_CATALOG")
+# ]
 bec, peaks = init_bec_peaks(iconfig)
 bec.disable_baseline()
 bec.enable_plots()

--- a/src/id4_common/utils/run_engine.py
+++ b/src/id4_common/utils/run_engine.py
@@ -9,8 +9,7 @@ Setup the Bluesky RunEngine, provides ``RE`` and ``sd``.
     ~peaks
 """
 
-# from apsbits.core.run_engine_init import init_RE
-from .run_engine_init import init_RE
+from apsbits.core.run_engine_init import init_RE
 from apsbits.core.best_effort_init import init_bec_peaks
 from apsbits.utils.config_loaders import get_config
 from apsbits.core.catalog_init import init_catalog
@@ -20,4 +19,4 @@ cat = init_catalog(iconfig)
 bec, peaks = init_bec_peaks(iconfig)
 bec.disable_baseline()
 bec.enable_plots()
-RE, sd = init_RE(iconfig, bec_instance=bec, cat_instance=cat)
+RE, sd = init_RE(iconfig, subscribers=[bec, cat])

--- a/src/id4_g/configs/iconfig_extras.yml
+++ b/src/id4_g/configs/iconfig_extras.yml
@@ -7,14 +7,13 @@ ICONFIG_VERSION: 2.0.0
 STATION: 4idg
 
 ### The short name for the databroker catalog.
-DATABROKER_CATALOG: &databroker_catalog 4id_polar
+DATABROKER_CATALOG: 4id_polar
 
 ### RunEngine configuration
 RUN_ENGINE:
     DEFAULT_METADATA:
         beamline_id: 4id-polar
         instrument_name: polar-4idg
-        databroker_catalog: *databroker_catalog
 
     ### EPICS PV to use for the `scan_id`.
     ### Default: `RE.md["scan_id"]` (not using an EPICS PV)

--- a/src/id4_g/startup.py
+++ b/src/id4_g/startup.py
@@ -63,6 +63,7 @@ from id4_common.utils.run_engine import (  # noqa: F401, E402
     sd,
     bec,
     cat,
+    cat_legacy,
     peaks,
 )
 

--- a/src/id4_g/startup.py
+++ b/src/id4_g/startup.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from apsbits.core.instrument_init import make_devices
 from apsbits.core.instrument_init import oregistry
 from apsbits.core.instrument_init import instrument  # noqa: F401
-from apsbits.utils.aps_functions import aps_dm_setup  # TODO: is this correct?
+from id4_common.utils.aps_functions import aps_dm_setup
 from apsbits.utils.config_loaders import get_config
 from apsbits.utils.config_loaders import load_config
 from apsbits.utils.config_loaders import load_config_yaml
@@ -63,7 +63,7 @@ from id4_common.utils.run_engine import (  # noqa: F401, E402
     RE,
     sd,
     bec,
-    cat as full_cat,  # This is the whole beamline catalog, below we narrow it.
+    cat,
     peaks,
 )
 
@@ -145,7 +145,7 @@ else:
     from id4_common.plans import *  # noqa: F401, F403
 
 logger.info("Loading 4-ID-G devices, this can take a few minutes.")
-RE(make_devices(clear=True, file="devices.yml"))  # Create the devices.
+make_devices(clear=True, file="devices.yml", device_manager=instrument)
 stations = ["core", "4idg"]
 for device in oregistry.findall(stations):
     connect_device(device, raise_error=False)
@@ -158,10 +158,3 @@ select_engine_for_psi(get_huber_euler_psi())  # noqa: F40
 
 for sus in shutter_suspenders.values():
     RE.install_suspender(sus)
-
-# Use a subset of the catalog - just for this station
-# This helps sorting up if there is a mix up of the scan_ids when using
-# two stations at the same time.
-cat = db_query(  # noqa: F405
-    full_cat, dict(instrument_name=f'polar-{iconfig["STATION"]}')
-)

--- a/src/id4_g/startup.py
+++ b/src/id4_g/startup.py
@@ -12,9 +12,8 @@ Includes:
 import logging
 from pathlib import Path
 
+from apsbits.core.instrument_init import init_instrument
 from apsbits.core.instrument_init import make_devices
-from apsbits.core.instrument_init import oregistry
-from apsbits.core.instrument_init import instrument  # noqa: F401
 from id4_common.utils.aps_functions import aps_dm_setup
 from apsbits.utils.config_loaders import get_config
 from apsbits.utils.config_loaders import load_config
@@ -45,7 +44,7 @@ iconfig = get_config()
 
 logger.info("Starting Instrument with iconfig: %s", iconfig_path)
 
-# Discard oregistry items loaded above.
+instrument, oregistry = init_instrument("guarneri")
 oregistry.clear()
 
 # Configure the session with callbacks, devices, and plans.

--- a/src/id4_h/configs/iconfig_extras.yml
+++ b/src/id4_h/configs/iconfig_extras.yml
@@ -7,14 +7,13 @@ ICONFIG_VERSION: 2.0.1
 STATION: 4idh
 
 ### The short name for the databroker catalog.
-DATABROKER_CATALOG: &databroker_catalog 4id_polar
+DATABROKER_CATALOG: 4id_polar
 
 ### RunEngine configuration
 RUN_ENGINE:
     DEFAULT_METADATA:
         beamline_id: 4id-polar
         instrument_name: polar-4idh
-        databroker_catalog: *databroker_catalog
 
     ### EPICS PV to use for the `scan_id`.
     ### Default: `RE.md["scan_id"]` (not using an EPICS PV)

--- a/src/id4_h/startup.py
+++ b/src/id4_h/startup.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from apsbits.core.instrument_init import make_devices
 from apsbits.core.instrument_init import oregistry
 from apsbits.core.instrument_init import instrument  # noqa: F401
-from apsbits.utils.aps_functions import aps_dm_setup  # TODO: is this correct?
+from id4_common.utils.aps_functions import aps_dm_setup
 from apsbits.utils.config_loaders import get_config
 from apsbits.utils.config_loaders import load_config
 from apsbits.utils.config_loaders import load_config_yaml
@@ -63,7 +63,7 @@ from id4_common.utils.run_engine import (  # noqa: F401, E402
     RE,
     sd,
     bec,
-    cat as full_cat,  # This is the whole beamline catalog, below we narrow it.
+    cat,
     peaks,
 )
 
@@ -145,7 +145,7 @@ else:
     from id4_common.plans import *  # noqa: F401, F403
 
 logger.info("Loading 4-ID-H devices, this can take a few minutes.")
-RE(make_devices(clear=True, file="devices.yml"))  # Create the devices.
+make_devices(clear=True, file="devices.yml", device_manager=instrument)
 stations = ["core", "4idh"]
 for device in oregistry.findall(stations):
     connect_device(device, raise_error=False)
@@ -154,10 +154,3 @@ counters.plotselect(11, 0)
 
 for sus in shutter_suspenders.values():
     RE.install_suspender(sus)
-
-# Use a subset of the catalog - just for this station
-# This helps sorting up if there is a mix up of the scan_ids when using
-# two stations at the same time.
-cat = db_query(  # noqa: F405
-    full_cat, dict(instrument_name=f'polar-{iconfig["STATION"]}')
-)

--- a/src/id4_h/startup.py
+++ b/src/id4_h/startup.py
@@ -63,6 +63,7 @@ from id4_common.utils.run_engine import (  # noqa: F401, E402
     sd,
     bec,
     cat,
+    cat_legacy,
     peaks,
 )
 
@@ -116,7 +117,7 @@ else:
         suspender_change_sleep,
     )
 
-    from id4_common.utils.wax import wm, wax, wa_new  # noqa: F401
+    # from id4_common.utils.wax import wm, wax, wa_new  # noqa: F401
     from id4_common.utils.counters_class import counters  # noqa: F401
     from id4_common.utils.pr_setup import pr_setup  # noqa: F401
     from id4_common.utils.attenuator_utils import atten  # noqa: F401

--- a/src/id4_h/startup.py
+++ b/src/id4_h/startup.py
@@ -12,9 +12,8 @@ Includes:
 import logging
 from pathlib import Path
 
+from apsbits.core.instrument_init import init_instrument
 from apsbits.core.instrument_init import make_devices
-from apsbits.core.instrument_init import oregistry
-from apsbits.core.instrument_init import instrument  # noqa: F401
 from id4_common.utils.aps_functions import aps_dm_setup
 from apsbits.utils.config_loaders import get_config
 from apsbits.utils.config_loaders import load_config
@@ -45,7 +44,7 @@ iconfig = get_config()
 
 logger.info("Starting Instrument with iconfig: %s", iconfig_path)
 
-# Discard oregistry items loaded above.
+instrument, oregistry = init_instrument("guarneri")
 oregistry.clear()
 
 # Configure the session with callbacks, devices, and plans.

--- a/src/id4_raman/configs/iconfig_extras.yml
+++ b/src/id4_raman/configs/iconfig_extras.yml
@@ -4,10 +4,10 @@
 ICONFIG_VERSION: 2.0.1
 
 # Add additional configuration for use with your instrument.
-STATION: &station raman
+STATION: raman
 
 ### The short name for the databroker catalog.
-DATABROKER_CATALOG: &databroker_catalog 4id_polar
+DATABROKER_CATALOG: 4id_polar
 
 ### RunEngine configuration
 RUN_ENGINE:
@@ -15,7 +15,6 @@ RUN_ENGINE:
         beamline_id: 4id-polar
         instrument_name: 4id-raman
         proposal_id: internal
-        databroker_catalog: *databroker_catalog
 
     ### EPICS PV to use for the `scan_id`.
     ### Default: `RE.md["scan_id"]` (not using an EPICS PV)

--- a/src/id4_raman/startup.py
+++ b/src/id4_raman/startup.py
@@ -63,6 +63,7 @@ from id4_common.utils.run_engine import (  # noqa: F401, E402
     sd,
     bec,
     cat,
+    cat_legacy,
     peaks,
 )
 

--- a/src/id4_raman/startup.py
+++ b/src/id4_raman/startup.py
@@ -12,9 +12,8 @@ Includes:
 import logging
 from pathlib import Path
 
+from apsbits.core.instrument_init import init_instrument
 from apsbits.core.instrument_init import make_devices
-from apsbits.core.instrument_init import oregistry
-from apsbits.core.instrument_init import instrument  # noqa: F401
 from id4_common.utils.aps_functions import aps_dm_setup
 from apsbits.utils.config_loaders import get_config
 from apsbits.utils.config_loaders import load_config
@@ -45,7 +44,7 @@ iconfig = get_config()
 
 logger.info("Starting Instrument with iconfig: %s", iconfig_path)
 
-# Discard oregistry items loaded above.
+instrument, oregistry = init_instrument("guarneri")
 oregistry.clear()
 
 # Configure the session with callbacks, devices, and plans.

--- a/src/id4_raman/startup.py
+++ b/src/id4_raman/startup.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from apsbits.core.instrument_init import make_devices
 from apsbits.core.instrument_init import oregistry
 from apsbits.core.instrument_init import instrument  # noqa: F401
-from apsbits.utils.aps_functions import aps_dm_setup  # TODO: is this correct?
+from id4_common.utils.aps_functions import aps_dm_setup
 from apsbits.utils.config_loaders import get_config
 from apsbits.utils.config_loaders import load_config
 from apsbits.utils.config_loaders import load_config_yaml
@@ -63,7 +63,7 @@ from id4_common.utils.run_engine import (  # noqa: F401, E402
     RE,
     sd,
     bec,
-    cat as full_cat,  # This is the whole beamline catalog, below we narrow it.
+    cat,
     peaks,
 )
 
@@ -145,7 +145,7 @@ else:
     from id4_common.plans import *  # noqa: F401, F403
 
 logger.info("Loading 4-ID-B devices, this can take a few minutes.")
-RE(make_devices(clear=True, file="devices.yml"))  # Create the devices.
+make_devices(clear=True, file="devices.yml", device_manager=instrument)
 stations = ["4idb"]
 for device in oregistry.findall(stations):
     connect_device(device, raise_error=False)
@@ -154,10 +154,3 @@ counters.plotselect(11, 0)
 
 for sus in shutter_suspenders.values():
     RE.install_suspender(sus)
-
-# Use a subset of the catalog - just for this station
-# This helps sorting up if there is a mix up of the scan_ids when using
-# two stations at the same time.
-cat = db_query(  # noqa: F405
-    full_cat, dict(instrument_name=f'polar-{iconfig["STATION"]}')
-)


### PR DESCRIPTION
Updates the startups to better match and use latest apsbits (2.0.1).

We will not change to Tiled for now but left the placeholders in `src/id4_common/utils/run_engine.py` and `src/id4_common/configs/iconfig.yml`. Ran into issue #28 and #29 while working on this.

Fixes #25 
