### PR TITLE
Address #20, #40, #43, #44, #51 plus load_vortex parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,8 @@ Configuration is YAML-driven. The main file is `src/id4_common/configs/iconfig.y
 - Enabled output formats (SPEC `.dat` files enabled by default, NeXus `.hdf` optional)
 - APS Data Management (DM) integration paths
 - Area detector defaults (Eiger 1M, Lambda, Vortex, LightField, Vimba)
-- EPICS timeouts and logging paths
+- EPICS timeouts
+- Bluesky session logging (`LOGGING.LOG_PATH` and friends — see "Logging" below)
 
 Device definitions live in `src/id4_common/configs/devices.yml` — the single source of truth for all beamlines. Each device entry maps a Python class path to EPICS PV prefixes, labels, and any extra kwargs the class `__init__` requires.
 
@@ -173,6 +174,17 @@ reload_all_devices()                             # reload all from YAML (all sta
 reload_all_devices(stations=["core", "4idh"])  # reload for a specific beamline
 ```
 
+`load_device(name)` is also the canonical way to **reconnect** a device that
+is already in the registry — it routes existing entries through
+`connect_device(...)` rather than skipping. Users who want to retry a flaky
+IOC connection can just call `load_device("...")` again.
+
+The vortex-specific helper `load_vortex(electronic, ...)` (used because vortex
+electronics are picked at runtime rather than from `devices.yml`) follows the
+same contract as `load_device`: it delegates to `connect_device`, runs
+`_post_connect_setup`/`default_settings`/HDF1 priming, and adds the device to
+`__main__` regardless of whether the connection succeeded.
+
 The `oregistry` (from `apsbits`) is the central device registry.
 
 ### Deferred EPICS Connection Pattern
@@ -210,11 +222,33 @@ class MyDevice(Device):
 For sub-components (not top-level `devices.yml` entries), use `run=False` on all
 `subscribe()` calls in `__init__` to avoid fetching PV values before connection.
 
+**HDF1 plugin priming.** `connect_device()` automatically calls
+`AD_prime_plugin2(device.hdf1)` after `default_settings()` runs, which fires
+`hdf1.warmup()` when the plugin has never received an array. The contract is
+that each area-detector class wires `self.hdf1.warmup_signals` inside its
+`default_settings()` — a list of `(signal, value)` pairs that briefly trigger
+one acquisition. Reference patterns: `Eiger1MDetector`, `VimbaDetector` (ADCore
+`acquire`); `VortexDante1`/`VortexDante4` (MCA `acquire_start`/`mca_mode`).
+A camera with no warmup signals logs a warning and skips priming.
+
 ### Data Output
 
-- **SPEC files** (`.dat`): enabled by default in `iconfig.yml`; `newSpecFile()`, `spec_comment()` available in session
+- **SPEC files** (`.dat`): enabled by default in `iconfig.yml`; `newSpecFile()`, `spec_comment()` available in session. The local writer (`id4_common.callbacks.apstools_spec_file_writer.SpecWriterCallback2`) collapses non-scalar metadata to one line via `_one_line()` and replaces array-valued scan args with a `<array len=N>` summary in the `#S` line so pymca can parse `qxscan` files.
 - **NeXus/HDF5** (`.hdf`): opt-in via `iconfig.yml`
 - **Dichro stream**: circular dichroism data processing, always loaded
+
+### Logging
+
+Bluesky session logs are configured by the `LOGGING` block of `iconfig.yml`,
+not by apsbits' default `logging.yml`. `id4_common.utils.logging_helper.
+setup_logging()` (called from each beamline's `__init__.py`) reads the block,
+translates `LOG_PATH`/`MAX_BYTES`/`NUMBER_OF_PREVIOUS_BACKUPS` to the apsbits
+`file_logs`/`ipython_logs` schema, writes a temp YAML, and passes it via
+`configure_logging(extra_logging_configs_path=...)`. If the centralized log
+directory cannot be created (developer machine without `/net/...` access)
+the helper falls back to apsbits' default `<cwd>/.logs/`. Add a new
+user-friendly key here by extending the `_FILE_LOGS_KEY_MAP` dict in
+`logging_helper.py`.
 
 ### QueueServer
 

--- a/docs/source/examples/general.md
+++ b/docs/source/examples/general.md
@@ -306,7 +306,8 @@ df = load_table(-1, cat)
 Configure which devices follow the monochromator when energy changes:
 
 ```python
-# Iterative. Displays the available devices and you enter their corresponding numbers
+# Iterative. Displays the available devices and you enter their corresponding
+# numbers.  Enter `0` to disable tracking on every device.
 energy.tracking_setup()
 # Or not interactive:
 energy.tracking_setup(["undulators_ds", "pr2"])

--- a/src/id4_b/__init__.py
+++ b/src/id4_b/__init__.py
@@ -5,6 +5,6 @@ This package provides a demo instrument implementation
 for testing and development.
 """
 
-from apsbits.utils.logging_setup import configure_logging
+from id4_common.utils.logging_helper import setup_logging
 
-configure_logging()
+setup_logging()

--- a/src/id4_common/__init__.py
+++ b/src/id4_common/__init__.py
@@ -5,6 +5,6 @@ This package provides a demo instrument implementation
 for testing and development.
 """
 
-from apsbits.utils.logging_setup import configure_logging
+from id4_common.utils.logging_helper import setup_logging
 
-configure_logging()
+setup_logging()

--- a/src/id4_common/callbacks/apstools_spec_file_writer.py
+++ b/src/id4_common/callbacks/apstools_spec_file_writer.py
@@ -70,6 +70,24 @@ SPEC_TIME_FORMAT = "%a %b %d %H:%M:%S %Y"
 SCAN_ID_RESET_VALUE = 0
 
 
+def _one_line(value):
+    """
+    Render *value* as a single line so SPEC's `#`-tagged structure stays intact.
+
+    Long lists / numpy arrays get a line-wrapped repr by default which produces
+    bare lines without a leading SPEC tag, breaking parsers like pymca.
+    Collapsing all whitespace (including newlines) into single spaces keeps the
+    metadata on one line and lets pymca read the file.
+    """
+    if isinstance(value, np.ndarray):
+        text = np.array2string(
+            value, separator=", ", max_line_width=10**9, threshold=10**9
+        )
+    else:
+        text = str(value)
+    return " ".join(text.split())
+
+
 def _rebuild_scan_command(doc):
     """
     reconstruct the scan command for SPEC data file #S line
@@ -96,6 +114,16 @@ def _rebuild_scan_command(doc):
                     'user_offset', 'user_offset_dir'])
         return: "m1"
         """
+        # Compact representation for non-ophyd, list-like arguments — e.g.
+        # the long energy / time arrays threaded through `qxscan` via
+        # `list_scan`.  Inlining the whole array would blow up the `#S` line
+        # into something pymca and other SPEC parsers reject as the scan
+        # command.  The full values still live in the `#MD plan_args` line.
+        if isinstance(src, np.ndarray):
+            return f"<array len={src.size}>"
+        if isinstance(src, (list, tuple)) and len(src) > 4:
+            return f"<{type(src).__name__} len={len(src)}>"
+
         s = str(src)
         p = s.find("(")
         if p > 0:  # only if an open parenthesis is found
@@ -1061,7 +1089,9 @@ class SpecWriterCallback2(FileWriterCallbackBase):
                 # Scan data is expected to be numbers. This is not.  Substitute
                 # the row number and report after this line in a #U line.
                 line.append(str(doc["seq_num"]))
-                remarks.append(f"#U {label} = {value}")
+                # Single-line so newlines/multi-line reprs cannot leak bare
+                # lines without a leading SPEC tag.
+                remarks.append(f"#U {label} = {_one_line(value)}")
 
         lines = [" ".join(line)]
         self._write_lines_(lines + remarks, mode="a+")
@@ -1082,7 +1112,7 @@ class SpecWriterCallback2(FileWriterCallbackBase):
         else:
             lines.append(self._cmt("exit_status = not available"))
 
-        self._write_lines_(lines, mode="a+")
+        self._write_lines_([_one_line(line) for line in lines], mode="a+")
 
     def write_scan_header(self):
         """Write scan header to file."""
@@ -1114,8 +1144,11 @@ class SpecWriterCallback2(FileWriterCallbackBase):
                 r += 1
 
         for k, v in self.metadata.items():
-            # "#MD" is our ad hoc SPEC data tag
-            lines.append(f"#MD {k} = {v}")
+            # "#MD" is our ad hoc SPEC data tag.  Force value to a single
+            # line so multi-line reprs (numpy arrays, line-wrapped lists,
+            # newline-containing strings) cannot emit bare lines without a
+            # leading SPEC tag — pymca rejects files that contain such lines.
+            lines.append(f"#MD {k} = {_one_line(v)}")
 
         lines.append("#N " + str(len(self.data_labels)))
         if len(self.data_labels) > 0:
@@ -1123,7 +1156,7 @@ class SpecWriterCallback2(FileWriterCallbackBase):
         else:
             lines.append("#C no data column labels identified")
 
-        self._write_lines_(lines, mode="a+")
+        self._write_lines_([_one_line(line) for line in lines], mode="a+")
 
         self.write_new_scan_header = False
 

--- a/src/id4_common/callbacks/apstools_spec_file_writer.py
+++ b/src/id4_common/callbacks/apstools_spec_file_writer.py
@@ -862,6 +862,8 @@ class SpecWriterCallback2(FileWriterCallbackBase):
             for k in self.motors.keys():
                 self.motors[k] = doc["data"][k]  # get motor values
             return
+        if descriptor["name"] != "primary":
+            return
 
         self.write_file_header()
         self.write_scan_header()

--- a/src/id4_common/configs/iconfig.yml
+++ b/src/id4_common/configs/iconfig.yml
@@ -84,13 +84,15 @@ OPHYD:
         PV_WRITE: *TIMEOUT
         PV_CONNECTION: *TIMEOUT
 
+### Bluesky session logging.  Read by `id4_common.utils.logging_helper.
+### setup_logging()` (called from each beamline's package `__init__.py`).
+### When `LOG_PATH` is unset (or unwritable on a dev machine) logs fall
+### back to `<cwd>/.logs/`.
 LOGGING:
-    ### Uncomment any of these to override the defaults
-    # MAX_BYTES: 1000000
-    NUMBER_OF_PREVIOUS_BACKUPS: 9
     LOG_PATH: /net/s4data/export/sector4/4idd/bluesky_logs
-    ### If LOG_PATH undefined, this session will log into PWD/logs/
-    ### where PWD is present working directory when session is started
+    # Uncomment to override apsbits defaults:
+    # MAX_BYTES: 1000000
+    # NUMBER_OF_PREVIOUS_BACKUPS: 9
 
 XMODE_DEBUG_LEVEL: Plain
 

--- a/src/id4_common/devices/ad_lambda.py
+++ b/src/id4_common/devices/ad_lambda.py
@@ -229,3 +229,12 @@ class Lambda250kDetector(MySingleTrigger, DetectorBase):
     def default_settings(self):
         """Apply default stage signal settings for the Lambda detector."""
         self.stage_sigs["cam.num_images"] = 1
+
+        self.hdf1.warmup_signals = [
+            (self.hdf1.enable, 1),
+            (self.hdf1.parent.cam.array_callbacks, 1),  # set by number
+            (self.hdf1.parent.cam.image_mode, 0),  # Single, set by number
+            (self.hdf1.parent.cam.trigger_mode, 0),  # Internal
+            (self.hdf1.parent.cam.acquire_time, 0.01),
+            (self.hdf1.parent.cam.acquire, 1),
+        ]

--- a/src/id4_common/devices/ad_mixins.py
+++ b/src/id4_common/devices/ad_mixins.py
@@ -281,6 +281,7 @@ class VortexDetectorCam(CamMixin_V34, Xspress3DetectorCam):
     erase_on_start = Component(
         EpicsSignal, "EraseOnStart", string=True, kind="config"
     )
+    data_type = ADComponent(EpicsSignalWithRBV, "DataType")
 
     # Removed
     offset = None

--- a/src/id4_common/devices/energy_device.py
+++ b/src/id4_common/devices/energy_device.py
@@ -146,6 +146,7 @@ class EnergySignal(Signal):
 
     def _tracking_prompts(self):
         _ = self.tracking
+        print("=== Enter 0 to disable tracking on all devices ===")
 
         current_selection = []
         for i, device in enumerate(self.trackable_devices):
@@ -156,7 +157,8 @@ class EnergySignal(Signal):
         while True:
             new_selection = (
                 input(
-                    f"\nEnter the index of the devices to track ({current_selection}): "
+                    f"\nEnter the index of the devices to track "
+                    f"(0 = none) ({current_selection}): "
                 )
                 or current_selection
             )
@@ -174,10 +176,15 @@ class EnergySignal(Signal):
                 continue
 
             if not all(
-                0 < i <= len(self.trackable_devices) for i in new_selection
+                0 <= i <= len(self.trackable_devices) for i in new_selection
             ):
                 logger.info("Invalid selection. Please choose valid indices.")
                 continue
+
+            # `0` means "disable tracking on all devices" — when present,
+            # ignore any other indices the user entered alongside it.
+            if 0 in new_selection:
+                new_selection = []
 
             break
 

--- a/src/id4_common/devices/vortex_dante_me1.py
+++ b/src/id4_common/devices/vortex_dante_me1.py
@@ -278,6 +278,7 @@ class VortexDante1(Trigger, ROICountersMixin, DetectorBase):
         self.hdf1.stage_sigs["num_capture"] = 0
         self.hdf1.stage_sigs["capture"] = 1
 
+        self.cam.mca_more.put("MCA Mapping")
         self.setup_manual_trigger()
         self.save_images_off()
         self.read_rois = [0]

--- a/src/id4_common/devices/vortex_dante_me1.py
+++ b/src/id4_common/devices/vortex_dante_me1.py
@@ -278,7 +278,7 @@ class VortexDante1(Trigger, ROICountersMixin, DetectorBase):
         self.hdf1.stage_sigs["num_capture"] = 0
         self.hdf1.stage_sigs["capture"] = 1
 
-        self.cam.mca_more.put("MCA Mapping")
+        self.cam.mca_mode.put("MCA Mapping")
         self.setup_manual_trigger()
         self.save_images_off()
         self.read_rois = [0]

--- a/src/id4_common/devices/vortex_dante_me1.py
+++ b/src/id4_common/devices/vortex_dante_me1.py
@@ -283,6 +283,17 @@ class VortexDante1(Trigger, ROICountersMixin, DetectorBase):
         self.read_rois = [0]
         self.plot_roi0()
 
+        # Dante uses MCA mode + EraseStart/StopAll to acquire (no `acquire`
+        # signal like ADCore detectors), so the warmup sequence pushes a
+        # short MCA acquisition through the plugin.
+        self.hdf1.warmup_signals = [
+            (self.hdf1.enable, 1),
+            (self.hdf1.parent.cam.array_callbacks, 1),
+            (self.hdf1.parent.cam.mca_mode, 0),  # MCA
+            (self.hdf1.parent.cam.real_time_preset, 0.1),
+            (self.hdf1.parent.cam.acquire_start, 1),
+        ]
+
         for item in "mca1".split():
             mca = getattr(self.mcas, item)
             mca.preset_real_time.kind = "omitted"

--- a/src/id4_common/devices/vortex_dante_me4.py
+++ b/src/id4_common/devices/vortex_dante_me4.py
@@ -281,6 +281,17 @@ class VortexDante4(Trigger, ROICountersMixin, DetectorBase):
         self.read_rois = [0]
         self.plot_roi0()
 
+        # Dante uses MCA mode + EraseStart/StopAll to acquire (no `acquire`
+        # signal like ADCore detectors), so the warmup sequence pushes a
+        # short MCA acquisition through the plugin.
+        self.hdf1.warmup_signals = [
+            (self.hdf1.enable, 1),
+            (self.hdf1.parent.cam.array_callbacks, 1),
+            (self.hdf1.parent.cam.mca_mode, 0),  # MCA
+            (self.hdf1.parent.cam.real_time_preset, 0.1),
+            (self.hdf1.parent.cam.acquire_start, 1),
+        ]
+
         for item in "mca1 mca2 mca3 mca4".split():
             mca = getattr(self.mcas, item)
             mca.preset_real_time.kind = "omitted"

--- a/src/id4_common/devices/vortex_xspress3_me4.py
+++ b/src/id4_common/devices/vortex_xspress3_me4.py
@@ -475,6 +475,15 @@ class VortexXspress34(Trigger, ROICountersMixin, DetectorBase):
             if "blocking_callbacks" in dir(obj):  # is it a plugin?
                 obj.stage_sigs["blocking_callbacks"] = "No"
 
+        self.hdf1.warmup_signals = [
+            (self.hdf1.enable, 1),
+            (self.hdf1.parent.cam.array_callbacks, 1),
+            (self.hdf1.parent.cam.image_mode, 0),  # Single
+            (self.hdf1.parent.cam.trigger_mode, 1),  # Internal
+            (self.hdf1.parent.cam.acquire_time, 0.01),
+            (self.hdf1.parent.cam.acquire, 1),
+        ]
+
     @property
     def read_rois(self):
         """

--- a/src/id4_common/devices/vortex_xspress3_me4.py
+++ b/src/id4_common/devices/vortex_xspress3_me4.py
@@ -6,7 +6,6 @@ from logging import getLogger
 from pathlib import Path
 from time import time as ttime
 
-import numpy as np
 from apsbits.core.instrument_init import oregistry
 from bluesky.plan_stubs import wait_for
 from ophyd import ADComponent
@@ -383,28 +382,6 @@ class VortexXspress34(Trigger, ROICountersMixin, DetectorBase):
         super().__init__(*args, **kwargs)
 
     _preset_monitor_attr = "cam.acquire_time"
-
-    def make_data_key(self):
-        """Override DetectorBase.make_data_key for the Xspress3 cam.
-
-        Upstream `Xspress3DetectorCam` lacks a `data_type` Component (unlike
-        `EigerDetectorCam` and `DanteCAM1`), so the base implementation
-        crashes with `AttributeError: 'NoneType' object has no attribute
-        'get'` whenever the HDF1 plugin is asked to describe itself — i.e.
-        on every scan after `auto_save_on()`.  Hardcode the spectrum dtype
-        to `uint32`, which is what the Xspress3 IOC writes to HDF5.
-        """
-        return dict(
-            external="FILESTORE:",
-            dtype="array",
-            shape=[
-                self.cam.num_images.get(),
-                self.cam.array_size.array_size_y.get(),
-                self.cam.array_size.array_size_x.get(),
-            ],
-            source=f"PV:{self.prefix}",
-            dtype_numpy=np.dtype("uint32").str,
-        )
 
     def align_on(self, time=0.1):
         """Start detector in alignment mode"""

--- a/src/id4_common/devices/vortex_xspress3_me4.py
+++ b/src/id4_common/devices/vortex_xspress3_me4.py
@@ -6,6 +6,7 @@ from logging import getLogger
 from pathlib import Path
 from time import time as ttime
 
+import numpy as np
 from apsbits.core.instrument_init import oregistry
 from bluesky.plan_stubs import wait_for
 from ophyd import ADComponent
@@ -382,6 +383,28 @@ class VortexXspress34(Trigger, ROICountersMixin, DetectorBase):
         super().__init__(*args, **kwargs)
 
     _preset_monitor_attr = "cam.acquire_time"
+
+    def make_data_key(self):
+        """Override DetectorBase.make_data_key for the Xspress3 cam.
+
+        Upstream `Xspress3DetectorCam` lacks a `data_type` Component (unlike
+        `EigerDetectorCam` and `DanteCAM1`), so the base implementation
+        crashes with `AttributeError: 'NoneType' object has no attribute
+        'get'` whenever the HDF1 plugin is asked to describe itself — i.e.
+        on every scan after `auto_save_on()`.  Hardcode the spectrum dtype
+        to `uint32`, which is what the Xspress3 IOC writes to HDF5.
+        """
+        return dict(
+            external="FILESTORE:",
+            dtype="array",
+            shape=[
+                self.cam.num_images.get(),
+                self.cam.array_size.array_size_y.get(),
+                self.cam.array_size.array_size_x.get(),
+            ],
+            source=f"PV:{self.prefix}",
+            dtype_numpy=np.dtype("uint32").str,
+        )
 
     def align_on(self, time=0.1):
         """Start detector in alignment mode"""

--- a/src/id4_common/devices/vortex_xspress3_me7.py
+++ b/src/id4_common/devices/vortex_xspress3_me7.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from time import sleep
 from time import time as ttime
 
-import numpy as np
 from apsbits.core.instrument_init import oregistry
 from bluesky.plan_stubs import wait_for
 from ophyd import ADComponent
@@ -401,28 +400,6 @@ class VortexXspress37(Trigger, ROICountersMixin, DetectorBase):
         super().__init__(*args, **kwargs)
 
     _preset_monitor_attr = "cam.acquire_time"
-
-    def make_data_key(self):
-        """Override DetectorBase.make_data_key for the Xspress3 cam.
-
-        Upstream `Xspress3DetectorCam` lacks a `data_type` Component (unlike
-        `EigerDetectorCam` and `DanteCAM1`), so the base implementation
-        crashes with `AttributeError: 'NoneType' object has no attribute
-        'get'` whenever the HDF1 plugin is asked to describe itself — i.e.
-        on every scan after `auto_save_on()`.  Hardcode the spectrum dtype
-        to `uint32`, which is what the Xspress3 IOC writes to HDF5.
-        """
-        return dict(
-            external="FILESTORE:",
-            dtype="array",
-            shape=[
-                self.cam.num_images.get(),
-                self.cam.array_size.array_size_y.get(),
-                self.cam.array_size.array_size_x.get(),
-            ],
-            source=f"PV:{self.prefix}",
-            dtype_numpy=np.dtype("uint32").str,
-        )
 
     @property
     def num_channels(self):

--- a/src/id4_common/devices/vortex_xspress3_me7.py
+++ b/src/id4_common/devices/vortex_xspress3_me7.py
@@ -499,6 +499,15 @@ class VortexXspress37(Trigger, ROICountersMixin, DetectorBase):
             if "blocking_callbacks" in dir(obj):  # is it a plugin?
                 obj.stage_sigs["blocking_callbacks"] = "No"
 
+        self.hdf1.warmup_signals = [
+            (self.hdf1.enable, 1),
+            (self.hdf1.parent.cam.array_callbacks, 1),
+            (self.hdf1.parent.cam.image_mode, 0),  # Single
+            (self.hdf1.parent.cam.trigger_mode, 1),  # Internal
+            (self.hdf1.parent.cam.acquire_time, 0.01),
+            (self.hdf1.parent.cam.acquire, 1),
+        ]
+
     @property
     def read_rois(self):
         """

--- a/src/id4_common/devices/vortex_xspress3_me7.py
+++ b/src/id4_common/devices/vortex_xspress3_me7.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from time import sleep
 from time import time as ttime
 
+import numpy as np
 from apsbits.core.instrument_init import oregistry
 from bluesky.plan_stubs import wait_for
 from ophyd import ADComponent
@@ -400,6 +401,28 @@ class VortexXspress37(Trigger, ROICountersMixin, DetectorBase):
         super().__init__(*args, **kwargs)
 
     _preset_monitor_attr = "cam.acquire_time"
+
+    def make_data_key(self):
+        """Override DetectorBase.make_data_key for the Xspress3 cam.
+
+        Upstream `Xspress3DetectorCam` lacks a `data_type` Component (unlike
+        `EigerDetectorCam` and `DanteCAM1`), so the base implementation
+        crashes with `AttributeError: 'NoneType' object has no attribute
+        'get'` whenever the HDF1 plugin is asked to describe itself — i.e.
+        on every scan after `auto_save_on()`.  Hardcode the spectrum dtype
+        to `uint32`, which is what the Xspress3 IOC writes to HDF5.
+        """
+        return dict(
+            external="FILESTORE:",
+            dtype="array",
+            shape=[
+                self.cam.num_images.get(),
+                self.cam.array_size.array_size_y.get(),
+                self.cam.array_size.array_size_x.get(),
+            ],
+            source=f"PV:{self.prefix}",
+            dtype_numpy=np.dtype("uint32").str,
+        )
 
     @property
     def num_channels(self):

--- a/src/id4_common/utils/device_loader.py
+++ b/src/id4_common/utils/device_loader.py
@@ -256,18 +256,20 @@ def load_device(name, file=None):
 
     Notes
     -----
-    The function checks if the device already exists in the registry.
-    If not, it loads the device configuration, dynamically imports the
-    device class, and connects the device. The device is then added to
-    the main namespace and optionally to the baseline if specified in
-    the configuration.
+    If the device is already registered, this function attempts to (re)connect
+    it via :func:`connect_device` instead of skipping. Otherwise, it loads the
+    device configuration, dynamically imports the device class, instantiates
+    the device, connects it, and adds it to the main namespace (and to the
+    baseline if specified in the configuration).
     """
 
-    if oregistry.find(name, allow_none=True) is not None:
-        logger.warning(
-            "The device already exists in the registry. If was not connected, "
-            "see `connect_device` function"
+    existing = oregistry.find(name, allow_none=True)
+    if existing is not None:
+        logger.info(
+            "Device %r already in the registry — attempting to (re)connect.",
+            name,
         )
+        connect_device(existing, raise_error=False)
         return
 
     # Load devices from specified file or default file

--- a/src/id4_common/utils/experiment_utils.py
+++ b/src/id4_common/utils/experiment_utils.py
@@ -9,7 +9,7 @@ Public API
     ~experiment
     ~experiment_setup
     ~experiment_change_sample
-    ~experiment_load_from_bluesky
+    ~experiment_load_from_scan
     ~experiment_resume
 """
 
@@ -45,7 +45,7 @@ __all__ = """
     experiment
     experiment_setup
     experiment_change_sample
-    experiment_load_from_bluesky
+    experiment_load_from_scan
     experiment_resume
 """.split()
 
@@ -599,77 +599,32 @@ class ExperimentClass:
             logger.warning("Could not load %s: %s", path, exc)
             return None
 
-    def _discover_resume_path(self) -> Path | None:
-        """Find a snapshot to resume from.
+    def _restore_from_md(self) -> bool:
+        """Populate singleton state from RE.md.
 
-        Probes the current working directory and the last scan's
-        recorded ``base_experiment_path``. Returns the snapshot file if
-        exactly one is found, prompts the user when both exist and
-        differ, returns ``None`` (with a warning logged) when neither
-        is available.
+        Returns False (and logs a warning) when no prior experiment is
+        recorded in RE.md.
         """
-        cwd_candidate = Path.cwd() / PERSIST_FILENAME
-
-        cat_candidate: Path | None = None
-        try:
-            cat_base = cat[-1].metadata["start"]["base_experiment_path"]
-            cat_candidate = Path(cat_base) / PERSIST_FILENAME
-        except Exception as exc:  # noqa: BLE001 — anything goes for cat lookup
-            logger.debug(
-                "Could not read base_experiment_path from cat[-1]: %s", exc
+        if not RE.md.get("experiment_name"):
+            logger.warning(
+                "No prior experiment found in RE.md — run "
+                "experiment_setup() first, or call "
+                "experiment_resume(path=...) with a saved YAML."
             )
+            return False
+        self.esaf = RE.md.get("esaf_id")
+        self.proposal = RE.md.get("proposal_id")
+        self.server = RE.md.get("server")
+        self.experiment_name = RE.md.get("experiment_name")
+        self.sample = RE.md.get("sample")
+        self.file_base_name = RE.md.get("base_name")
+        bep = RE.md.get("base_experiment_path")
+        self.base_experiment_path = Path(bep) if bep else None
+        # scan_id is already in RE.md (PersistentDict restored it).
+        return True
 
-        cwd_ok = cwd_candidate.is_file()
-        cat_ok = cat_candidate is not None and cat_candidate.is_file()
-
-        if (
-            cwd_ok
-            and cat_ok
-            and cwd_candidate.resolve() != cat_candidate.resolve()
-        ):
-            choice = (
-                self._prompt(
-                    "Two experiment snapshots found:\n"
-                    f"  1: {cwd_candidate} (current directory)\n"
-                    f"  2: {cat_candidate} (last scan)\n"
-                    "Which one to resume? [1]: "
-                )
-                or "1"
-            ).strip()
-            return cat_candidate if choice == "2" else cwd_candidate
-
-        if cwd_ok:
-            return cwd_candidate
-        if cat_ok:
-            return cat_candidate
-
-        logger.warning(
-            "No experiment snapshot found (looked in %s and via cat[-1]).",
-            cwd_candidate,
-        )
-        return None
-
-    def resume(self, path: str | Path | None = None) -> None:
-        """Restore an experiment from a saved YAML snapshot.
-
-        With no ``path``, discovers the snapshot automatically: prefers
-        ``Path.cwd() / .polar_experiment.yml`` and falls back to the
-        ``base_experiment_path`` stored in ``cat[-1]``'s start
-        document. Prompts the user only when both exist and point at
-        different files.
-
-        Does NOT contact DM. Use this when DM is down or you want to
-        pick up a previous session quickly. The next scan continues
-        numbering from ``last_scan_id``.
-        """
-        if path is None:
-            path = self._discover_resume_path()
-            if path is None:
-                return
-        snapshot = self.load_params_from_yaml(path)
-        if snapshot is None:
-            return
-
+    def _populate_from_snapshot(self, snapshot: dict) -> None:
+        """Populate singleton + RE.md from a YAML snapshot dict."""
         self.esaf = snapshot.get("esaf_id")
         self.proposal = snapshot.get("proposal_id")
         self.server = snapshot.get("server")
@@ -694,11 +649,33 @@ class ExperimentClass:
             if value is not None:
                 RE.md[key] = str(value) if key.endswith("_id") else value
 
+        if self.base_experiment_path is not None:
+            RE.md["base_experiment_path"] = str(self.base_experiment_path)
+
         last_scan = snapshot.get("last_scan_id")
         if isinstance(last_scan, int) and last_scan >= 0:
             RE.md["scan_id"] = last_scan
         else:
             RE.md.setdefault("scan_id", 0)
+
+    def resume(self, path: str | Path | None = None) -> None:
+        """Restore an experiment after a Bluesky restart.
+
+        With no ``path``, restores singleton state from ``RE.md`` (the
+        PersistentDict bluesky already loaded at startup). With an
+        explicit ``path``, loads the snapshot YAML at that location and
+        populates both singleton state and ``RE.md`` from it.
+
+        Does NOT contact DM either way.
+        """
+        if path is None:
+            if not self._restore_from_md():
+                return
+        else:
+            snapshot = self.load_params_from_yaml(path)
+            if snapshot is None:
+                return
+            self._populate_from_snapshot(snapshot)
 
         if self.base_experiment_path is not None and self.sample is not None:
             self.setup_path()
@@ -769,6 +746,8 @@ class ExperimentClass:
                 )
             else:
                 self.windows_base_experiment_path = None
+
+        RE.md["base_experiment_path"] = str(self.base_experiment_path)
 
     def setup(
         self,
@@ -844,7 +823,6 @@ class ExperimentClass:
             RE.md["scan_id"] = 0
 
         self.start_specwriter()
-        self.save_params_to_yaml()
 
         self._printer(self.__repr__())
 
@@ -860,7 +838,6 @@ class ExperimentClass:
         self.scan_number_input(reset_scan_id)
         self.base_name_input(base_name)
         self.start_specwriter()
-        self.save_params_to_yaml()
 
     def __call__(
         self,
@@ -921,7 +898,7 @@ def experiment_change_sample(
     )
 
 
-def experiment_load_from_bluesky(
+def experiment_load_from_scan(
     scan_id: int =-1, reset_scan_id: int = RESET_SCAN_ID_NOOP,
 ) -> None:
     """Restore experiment state from a previous Bluesky run."""
@@ -929,9 +906,10 @@ def experiment_load_from_bluesky(
 
 
 def experiment_resume(path: str | Path | None = None) -> None:
-    """Restore experiment state from a saved YAML snapshot.
+    """Restore experiment state after a Bluesky restart.
 
-    With no argument, the snapshot path is auto-discovered (current
-    working directory, then last-scan ``base_experiment_path``).
+    With no argument, restores from ``RE.md`` (the PersistentDict
+    bluesky already loaded at startup). With an explicit ``path``,
+    loads the YAML snapshot at that location instead.
     """
     experiment.resume(path)

--- a/src/id4_common/utils/experiment_utils.py
+++ b/src/id4_common/utils/experiment_utils.py
@@ -899,7 +899,8 @@ def experiment_change_sample(
 
 
 def experiment_load_from_scan(
-    scan_id: int = -1, reset_scan_id: int = RESET_SCAN_ID_NOOP,
+    scan_id: int = -1,
+    reset_scan_id: int = RESET_SCAN_ID_NOOP,
 ) -> None:
     """Restore experiment state from a previous Bluesky run."""
     experiment.load_from_bluesky(scan_id=scan_id, reset_scan_id=reset_scan_id)

--- a/src/id4_common/utils/experiment_utils.py
+++ b/src/id4_common/utils/experiment_utils.py
@@ -899,7 +899,7 @@ def experiment_change_sample(
 
 
 def experiment_load_from_scan(
-    scan_id: int =-1, reset_scan_id: int = RESET_SCAN_ID_NOOP,
+    scan_id: int = -1, reset_scan_id: int = RESET_SCAN_ID_NOOP,
 ) -> None:
     """Restore experiment state from a previous Bluesky run."""
     experiment.load_from_bluesky(scan_id=scan_id, reset_scan_id=reset_scan_id)

--- a/src/id4_common/utils/experiment_utils.py
+++ b/src/id4_common/utils/experiment_utils.py
@@ -922,10 +922,10 @@ def experiment_change_sample(
 
 
 def experiment_load_from_bluesky(
-    reset_scan_id: int = RESET_SCAN_ID_NOOP,
+    scan_id: int =-1, reset_scan_id: int = RESET_SCAN_ID_NOOP,
 ) -> None:
     """Restore experiment state from a previous Bluesky run."""
-    experiment.load_from_bluesky(reset_scan_id=reset_scan_id)
+    experiment.load_from_bluesky(scan_id=scan_id, reset_scan_id=reset_scan_id)
 
 
 def experiment_resume(path: str | Path | None = None) -> None:

--- a/src/id4_common/utils/load_vortex.py
+++ b/src/id4_common/utils/load_vortex.py
@@ -10,6 +10,7 @@ from ..devices.vortex_dante_me4 import VortexDante4
 from ..devices.vortex_xmap import VortexXMAP
 from ..devices.vortex_xspress3_me4 import VortexXspress34
 from ..devices.vortex_xspress3_me7 import VortexXspress37
+from .device_loader import connect_device
 from .run_engine import sd
 
 logger = getLogger(__name__)
@@ -90,26 +91,26 @@ def load_vortex(
 
     device = vortexclass(pv, name=name, labels=labels, **kwargs)
 
-    try:
-        logger.info("Connecting to %s...", device.name)
-        device.wait_for_connection()
-        if baseline:
-            sd.baseline.append(device)
-        if hasattr(device, "default_settings"):
-            device.default_settings()
-        oregistry.register(device)
-        logger.info("Adding %r to the main namespace.", name)
-        setattr(sys.modules["__main__"], name, device)
-        if "dante" in electronic.lower():
-            message = (
-                "\n To prime, hdf, Acq.Mode needs to be in MCA mapping mode."
-            )
-            message += "\n with IOC with dpuser, vortex._local_folder = /local/home/dpuser/sector4/"
-            message += "\n with IOC with polar, vortex._local_folder = /net/s4data/export/sector4/4idd/bluesky_images/vortex"
-        logger.warning(message)
-    except TimeoutError:
-        message = f"Device {device.name} is disconnected."
-        if baseline:
-            message += " This device was not added to the baseline."
+    # Delegate the actual connect / register / baseline / hdf1-prime work to
+    # the shared helper so vortex devices behave identically to anything
+    # loaded via `load_device` (including the `_post_connect_setup` hook and
+    # the HDF1 warmup wired up in each device's `default_settings`).
+    connect_device(device, baseline=baseline, raise_error=False)
+
+    # Always expose the device in `__main__`, matching `load_device`.  Even
+    # if `connect_device` failed, the user gets the object back in their
+    # session and can retry via `connect_device(<name>)` or `load_vortex(...)`.
+    logger.info("Adding %r to the main namespace.", name)
+    setattr(sys.modules["__main__"], name, device)
+
+    if "dante" in electronic.lower():
+        logger.warning(
+            "\n To prime hdf, Acq.Mode needs to be in MCA mapping mode."
+            "\n with IOC with dpuser, "
+            "vortex._local_folder = /local/home/dpuser/sector4/"
+            "\n with IOC with polar, "
+            "vortex._local_folder = /net/s4data/export/sector4/4idd/"
+            "bluesky_images/vortex"
+        )
 
     return device

--- a/src/id4_common/utils/logging_helper.py
+++ b/src/id4_common/utils/logging_helper.py
@@ -36,6 +36,16 @@ def setup_logging():
     configured or when the centralized directory cannot be created — typically
     a developer machine without access to the beamline filesystem.
     """
+    # `apsbits/__init__.py` calls `configure_logging()` itself at import
+    # time (transitively triggered by the `from apsbits.utils.logging_setup
+    # import configure_logging` above), which fires `%logstart` against the
+    # apsbits default `<cwd>/.logs/ipython_log.py`.  IPython's `%logstart`
+    # is idempotent, so when our own `configure_logging` re-runs with the
+    # centralized override the second `%logstart` no-ops and the IPython
+    # log stays on the wrong path.  Stop the existing logger first so the
+    # next `%logstart` actually lands on the override.
+    _stop_active_ipython_log()
+
     overrides = _build_overrides()
     if not overrides:
         configure_logging()
@@ -57,6 +67,19 @@ def setup_logging():
         configure_logging()
     finally:
         os.unlink(tmp_path)
+
+
+def _stop_active_ipython_log():
+    """Stop any active IPython `%logstart` so the next one takes effect."""
+    try:
+        from IPython import get_ipython
+    except ImportError:
+        return
+    ip = get_ipython()
+    if ip is None:
+        return
+    if getattr(ip.logger, "log_active", False):
+        ip.run_line_magic("logstop", "")
 
 
 def _build_overrides():

--- a/src/id4_common/utils/logging_helper.py
+++ b/src/id4_common/utils/logging_helper.py
@@ -12,9 +12,7 @@ logger = logging.getLogger(__name__)
 
 # iconfig.yml is the single source of truth — including the LOGGING block.
 _ICONFIG = (
-    pathlib.Path(__file__).resolve().parent.parent
-    / "configs"
-    / "iconfig.yml"
+    pathlib.Path(__file__).resolve().parent.parent / "configs" / "iconfig.yml"
 )
 
 # Translation from POLAR-friendly keys (uppercase, in iconfig.yml's LOGGING

--- a/src/id4_common/utils/logging_helper.py
+++ b/src/id4_common/utils/logging_helper.py
@@ -1,12 +1,27 @@
 """Centralized bluesky-session logging configuration for POLAR beamlines."""
 
+import contextlib
+import io
 import logging
 import os
 import pathlib
 import tempfile
 
 import yaml
-from apsbits.utils.logging_setup import configure_logging
+
+# Importing `apsbits.utils.logging_setup` triggers `apsbits/__init__.py`,
+# which calls `configure_logging()` itself at module-init time.  That fires
+# `%logstart` against `<cwd>/.logs/ipython_log.py` and adds a file handler
+# to the same wrong location, before our own `setup_logging()` ever runs.
+# Both are immediately replaced by the centralized override below, so
+# silence the import-time print/log output here and tear down the stray
+# handler in `setup_logging()`.
+_silenced_init = io.StringIO()
+with (
+    contextlib.redirect_stdout(_silenced_init),
+    contextlib.redirect_stderr(_silenced_init),
+):
+    from apsbits.utils.logging_setup import configure_logging
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +37,16 @@ _FILE_LOGS_KEY_MAP = {
     "NUMBER_OF_PREVIOUS_BACKUPS": "backupCount",
 }
 
+# Filename for the IPython session log.  Override the apsbits default
+# (`ipython_log.py`) so the file is clearly a log, not a runnable script.
+_IPYTHON_LOG_FILENAME = "ipython_logs.log"
+
+# Idempotency guard: every beamline's package `__init__.py` calls
+# `setup_logging()` and they all transitively import id4_common (which also
+# calls `setup_logging()`), so without this guard the IPython-logging
+# settings block prints once per import.
+_setup_done = False
+
 
 def setup_logging():
     """
@@ -32,24 +57,51 @@ def setup_logging():
     ``configure_logging(extra_logging_configs_path=...)``) so polar-bits keeps
     a single config file.
 
-    Falls back to the apsbits default (``<cwd>/.logs/``) when no LOG_PATH is
-    configured or when the centralized directory cannot be created — typically
-    a developer machine without access to the beamline filesystem.
+    Falls back to the apsbits default directory (``<cwd>/.logs/``) when no
+    LOG_PATH is configured or when the centralized directory cannot be
+    created — typically a developer machine without access to the beamline
+    filesystem.  The IPython log file always uses our filename
+    (``ipython_logs.log``), regardless of which directory wins.
+
+    Idempotent: subsequent calls are no-ops so importing several beamline
+    packages (or importing one whose ``__init__.py`` chains through
+    id4_common) doesn't re-run `%logstart` and re-print the settings block.
     """
-    # `apsbits/__init__.py` calls `configure_logging()` itself at import
-    # time (transitively triggered by the `from apsbits.utils.logging_setup
-    # import configure_logging` above), which fires `%logstart` against the
-    # apsbits default `<cwd>/.logs/ipython_log.py`.  IPython's `%logstart`
-    # is idempotent, so when our own `configure_logging` re-runs with the
-    # centralized override the second `%logstart` no-ops and the IPython
-    # log stays on the wrong path.  Stop the existing logger first so the
-    # next `%logstart` actually lands on the override.
+    global _setup_done
+    if _setup_done:
+        return
+
+    # Tear down handlers/loggers left over from the apsbits import-time
+    # configure_logging() so file logs don't get written twice and the next
+    # `%logstart` actually lands on our override path.
+    _drop_apsbits_init_file_handlers()
     _stop_active_ipython_log()
 
-    overrides = _build_overrides()
-    if not overrides:
-        configure_logging()
-        return
+    cfg = _read_iconfig_logging_block()
+    log_path = cfg.get("LOG_PATH")
+
+    if log_path:
+        try:
+            _apply_overrides(log_path=log_path, cfg=cfg)
+        except (PermissionError, OSError) as exc:
+            print(
+                "POLAR centralized log directory unavailable "
+                f"({exc}); falling back to <cwd>/.logs/."
+            )
+            # Tear down whatever partial handlers the failed run left behind
+            # and try again with the apsbits default directory.
+            _drop_apsbits_init_file_handlers()
+            _stop_active_ipython_log()
+            _apply_overrides(log_path=None, cfg=cfg)
+    else:
+        _apply_overrides(log_path=None, cfg=cfg)
+
+    _setup_done = True
+
+
+def _apply_overrides(log_path, cfg):
+    """Run apsbits' configure_logging with the polar overrides applied."""
+    overrides = _build_overrides(log_path=log_path, cfg=cfg)
 
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".yml", delete=False
@@ -59,14 +111,48 @@ def setup_logging():
 
     try:
         configure_logging(extra_logging_configs_path=tmp_path)
-    except (PermissionError, OSError) as exc:
-        print(
-            "POLAR centralized log directory unavailable "
-            f"({exc}); falling back to <cwd>/.logs/."
-        )
-        configure_logging()
     finally:
         os.unlink(tmp_path)
+
+
+def _build_overrides(log_path, cfg):
+    """Build the apsbits-shape override dict for one configure_logging run.
+
+    The IPython filename override is always applied.  The directory override
+    and any file_logs knobs (max bytes, backup count) are applied only when
+    log_path is non-None.
+    """
+    ipython_logs = {"log_filename_base": _IPYTHON_LOG_FILENAME}
+    file_logs = {}
+    if log_path:
+        ipython_logs["log_directory"] = log_path
+        file_logs["log_directory"] = log_path
+        for src_key, dst_key in _FILE_LOGS_KEY_MAP.items():
+            if src_key in cfg:
+                file_logs[dst_key] = cfg[src_key]
+
+    overrides = {"ipython_logs": ipython_logs}
+    if file_logs:
+        overrides["file_logs"] = file_logs
+    return overrides
+
+
+def _read_iconfig_logging_block():
+    """Return iconfig.yml's LOGGING block as a dict (empty if missing)."""
+    if not _ICONFIG.exists():
+        return {}
+    with open(_ICONFIG) as f:
+        iconfig = yaml.safe_load(f) or {}
+    return iconfig.get("LOGGING") or {}
+
+
+def _drop_apsbits_init_file_handlers():
+    """Remove FileHandlers added by the apsbits import-time configure_logging."""
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if isinstance(handler, logging.FileHandler):
+            root.removeHandler(handler)
+            handler.close()
 
 
 def _stop_active_ipython_log():
@@ -80,27 +166,3 @@ def _stop_active_ipython_log():
         return
     if getattr(ip.logger, "log_active", False):
         ip.run_line_magic("logstop", "")
-
-
-def _build_overrides():
-    """Translate iconfig.yml's LOGGING block into the apsbits logging schema."""
-    if not _ICONFIG.exists():
-        return None
-
-    with open(_ICONFIG) as f:
-        iconfig = yaml.safe_load(f) or {}
-
-    cfg = iconfig.get("LOGGING") or {}
-    log_path = cfg.get("LOG_PATH")
-    if not log_path:
-        return None
-
-    file_logs = {"log_directory": log_path}
-    for src_key, dst_key in _FILE_LOGS_KEY_MAP.items():
-        if src_key in cfg:
-            file_logs[dst_key] = cfg[src_key]
-
-    return {
-        "file_logs": file_logs,
-        "ipython_logs": {"log_directory": log_path},
-    }

--- a/src/id4_common/utils/logging_helper.py
+++ b/src/id4_common/utils/logging_helper.py
@@ -1,0 +1,85 @@
+"""Centralized bluesky-session logging configuration for POLAR beamlines."""
+
+import logging
+import os
+import pathlib
+import tempfile
+
+import yaml
+from apsbits.utils.logging_setup import configure_logging
+
+logger = logging.getLogger(__name__)
+
+# iconfig.yml is the single source of truth — including the LOGGING block.
+_ICONFIG = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "configs"
+    / "iconfig.yml"
+)
+
+# Translation from POLAR-friendly keys (uppercase, in iconfig.yml's LOGGING
+# block) to the apsbits `file_logs` schema.
+_FILE_LOGS_KEY_MAP = {
+    "MAX_BYTES": "maxBytes",
+    "NUMBER_OF_PREVIOUS_BACKUPS": "backupCount",
+}
+
+
+def setup_logging():
+    """
+    Configure bluesky logging from the LOGGING block of iconfig.yml.
+
+    The block is translated to the apsbits `file_logs`/`ipython_logs` schema
+    on the fly (via a temporary YAML file passed to apsbits'
+    ``configure_logging(extra_logging_configs_path=...)``) so polar-bits keeps
+    a single config file.
+
+    Falls back to the apsbits default (``<cwd>/.logs/``) when no LOG_PATH is
+    configured or when the centralized directory cannot be created — typically
+    a developer machine without access to the beamline filesystem.
+    """
+    overrides = _build_overrides()
+    if not overrides:
+        configure_logging()
+        return
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yml", delete=False
+    ) as fh:
+        yaml.safe_dump(overrides, fh)
+        tmp_path = fh.name
+
+    try:
+        configure_logging(extra_logging_configs_path=tmp_path)
+    except (PermissionError, OSError) as exc:
+        print(
+            "POLAR centralized log directory unavailable "
+            f"({exc}); falling back to <cwd>/.logs/."
+        )
+        configure_logging()
+    finally:
+        os.unlink(tmp_path)
+
+
+def _build_overrides():
+    """Translate iconfig.yml's LOGGING block into the apsbits logging schema."""
+    if not _ICONFIG.exists():
+        return None
+
+    with open(_ICONFIG) as f:
+        iconfig = yaml.safe_load(f) or {}
+
+    cfg = iconfig.get("LOGGING") or {}
+    log_path = cfg.get("LOG_PATH")
+    if not log_path:
+        return None
+
+    file_logs = {"log_directory": log_path}
+    for src_key, dst_key in _FILE_LOGS_KEY_MAP.items():
+        if src_key in cfg:
+            file_logs[dst_key] = cfg[src_key]
+
+    return {
+        "file_logs": file_logs,
+        "ipython_logs": {"log_directory": log_path},
+    }

--- a/src/id4_common/utils/run_engine.py
+++ b/src/id4_common/utils/run_engine.py
@@ -11,8 +11,9 @@ Setup the Bluesky RunEngine, provides ``RE`` and ``sd``.
 
 from apsbits.core.best_effort_init import init_bec_peaks
 from apsbits.core.catalog_init import init_catalog
-from id4_common.utils.run_engine_init import init_RE
 from apsbits.utils.config_loaders import get_config
+
+from id4_common.utils.run_engine_init import init_RE
 
 # from tiled.client import from_profile
 

--- a/src/id4_common/utils/run_engine.py
+++ b/src/id4_common/utils/run_engine.py
@@ -11,7 +11,7 @@ Setup the Bluesky RunEngine, provides ``RE`` and ``sd``.
 
 from apsbits.core.best_effort_init import init_bec_peaks
 from apsbits.core.catalog_init import init_catalog
-from apsbits.core.run_engine_init import init_RE
+from id4_common.utils.run_engine_init import init_RE
 from apsbits.utils.config_loaders import get_config
 
 # from tiled.client import from_profile

--- a/src/id4_common/utils/run_engine_init.py
+++ b/src/id4_common/utils/run_engine_init.py
@@ -2,20 +2,30 @@
 Setup and initialize the Bluesky RunEngine.
 ===========================================
 
-This module provides the function init_RE to create and configure a
-Bluesky RunEngine with metadata storage, subscriptions, and various
-settings based on a configuration dictionary.
+Local copy of ``apsbits.core.run_engine_init.init_RE`` that fixes the
+broken ``handler_name`` selector. Upstream apsbits 2.0.1 hard-codes
+``handler_name = StoredDict`` (the class object) and then compares it to
+the string ``"PersistentDict"`` / ``"StoredDict"`` — both branches are
+always False, so ``RE.md`` is never wired up to the on-disk
+PersistentDict and `scan_id` (etc.) never restore on startup.
+
+Drop this shim once apsbits ships a release that picks the handler from
+the path layout instead of pinning it to a class.
 
 .. autosummary::
     ~init_RE
 """
 
+import collections
 import logging
 from pathlib import Path
 from typing import Any
 from typing import Optional
 
 import bluesky
+import databroker._drivers.mongo_normalized
+import databroker._drivers.msgpack
+import tiled
 from apsbits.utils.controls_setup import connect_scan_id_pv
 from apsbits.utils.controls_setup import set_control_layer
 from apsbits.utils.controls_setup import set_timeouts
@@ -23,53 +33,24 @@ from apsbits.utils.metadata import get_md_path
 from apsbits.utils.metadata import re_metadata
 from apsbits.utils.stored_dict import StoredDict
 from bluesky.utils import ProgressBarManager
+from bluesky_tiled_plugins import TiledWriter
 
 logger = logging.getLogger(__name__)
 logger.bsdev(__file__)
 
 
 def init_RE(
-    iconfig: dict[str, Any],
-    bec_instance: Optional[Any] = None,
-    cat_instance: Optional[Any] = None,
+    iconfig: collections.abc.Mapping[str, Any],
+    subscribers: Optional[list[Any]] = None,
     **kwargs: Any,
 ) -> tuple[bluesky.RunEngine, bluesky.SupplementalData]:
-    """
-    Initialize and configure a Bluesky RunEngine instance.
+    """Initialize and configure a Bluesky RunEngine instance.
 
-    This function creates a Bluesky RunEngine, sets up metadata storage,
-    subscriptions, and various preprocessors based on the provided
-    configuration dictionary. It configures the control layer and timeouts,
-    attaches supplemental data for baselines and monitors, and optionally
-    adds a progress bar and metadata updates from a catalog or
-    BestEffortCallback.
-
-    Parameters:
-        iconfig (Dict[str, Any]): Configuration dictionary with keys:
-            - "RUN_ENGINE": A dict with RunEngine-specific settings.
-            - "DEFAULT_METADATA": (Optional) Default metadata.
-            - "USE_PROGRESS_BAR": (Optional) Boolean to enable progress bar.
-            - "OPHYD": A dict for control layer settings
-            (e.g., "CONTROL_LAYER" and "TIMEOUTS").
-        bec_instance (Optional[Any]): Instance of BestEffortCallback
-            for subscribing to the RunEngine. Defaults to None.
-        cat_instance (Optional[Any]): Instance of a databroker catalog
-            for subscribing to the RunEngine. Defaults to None.
-        **kwargs: Additional keyword arguments passed to the RunEngine
-            constructor. For example, run_returns_result=True.
-
-    Returns:
-        Tuple[bluesky.RunEngine, bluesky.SupplementalData]: A tuple
-        containing the configured RunEngine and its SupplementalData.
-
-    Notes:
-        The function attempts to set up persistent metadata storage in
-        the RE.md attr. If an error occurs during creation of the
-        metadata storage handler, the error is logged and the function
-        proceeds without persistent metadata. Subscriptions are added
-        for the catalog and BestEffortCallback if provided, and
-        additional configurations such as control layer, timeouts, and
-        progress bar integration are applied.
+    Mirrors :func:`apsbits.core.run_engine_init.init_RE`. The only
+    behavioural difference is :data:`handler_name`, which here selects
+    ``"StoredDict"`` for a file ``MD_PATH`` and ``"PersistentDict"``
+    otherwise — the upstream version hard-codes the class and never
+    actually restores from disk.
     """
     re_config = iconfig.get("RUN_ENGINE", {})
 
@@ -88,6 +69,9 @@ def init_RE(
     MD_PATH = get_md_path(iconfig)
     # Save/restore RE.md dictionary in the specified order.
     if MD_PATH is not None:
+        # The upstream apsbits bug: this line was `handler_name = StoredDict`
+        # (the class), which never compares equal to the string literals
+        # below — so `RE.md` was never wired to the on-disk PersistentDict.
         handler_name = (
             "StoredDict" if Path(MD_PATH).is_file() else "PersistentDict"
         )
@@ -108,14 +92,58 @@ def init_RE(
                 f"without saving metadata to disk. {error=}\n"
             )
 
-    if cat_instance is not None:
-        RE.md.update(
-            re_metadata(iconfig, cat_instance)
-        )  # programmatic metadata
-        RE.md.update(re_config.get("DEFAULT_METADATA", {}))
-        RE.subscribe(cat_instance.v1.insert)
-    if bec_instance is not None:
-        RE.subscribe(bec_instance)
+    RE.md.update(re_config.get("DEFAULT_METADATA", {}))
+    RE.md.update(re_metadata(iconfig))  # programmatic metadata
+
+    if subscribers:
+        for instance in subscribers:
+            if instance is None:
+                continue
+
+            # Check if it's a tiled client
+            if isinstance(instance, tiled.client.container.Container):
+                try:
+                    tiled_writer = TiledWriter(instance, batch_size=1)
+                    RE.subscribe(tiled_writer)
+                except Exception:
+                    logger.exception(
+                        "Failed to subscribe TiledWriter for tiled client %r "
+                        "(type=%s)",
+                        instance,
+                        type(instance).__name__,
+                    )
+                    raise
+
+            # Check if it's a databroker catalog
+            elif isinstance(
+                instance,
+                (
+                    databroker._drivers.msgpack.BlueskyMsgpackCatalog,
+                    databroker._drivers.mongo_normalized.BlueskyMongoCatalog,
+                ),
+            ):
+                try:
+                    RE.subscribe(instance.v1.insert)
+                except Exception:
+                    logger.exception(
+                        "Failed to subscribe databroker catalog insert for %r "
+                        "(type=%s)",
+                        instance,
+                        type(instance).__name__,
+                    )
+                    raise
+
+            # Default: subscribe directly (handles BEC and other callbacks)
+            else:
+                try:
+                    RE.subscribe(instance)
+                except Exception:
+                    logger.exception(
+                        "Failed to subscribe callback %r (type=%s)",
+                        instance,
+                        type(instance).__name__,
+                    )
+                    raise
 
     scan_id_pv = iconfig.get("RUN_ENGINE", {}).get("SCAN_ID_PV")
     connect_scan_id_pv(RE, pv=scan_id_pv)

--- a/src/id4_g/__init__.py
+++ b/src/id4_g/__init__.py
@@ -5,6 +5,6 @@ This package provides a demo instrument implementation
 for testing and development.
 """
 
-from apsbits.utils.logging_setup import configure_logging
+from id4_common.utils.logging_helper import setup_logging
 
-configure_logging()
+setup_logging()

--- a/src/id4_h/__init__.py
+++ b/src/id4_h/__init__.py
@@ -5,6 +5,6 @@ This package provides a demo instrument implementation
 for testing and development.
 """
 
-from apsbits.utils.logging_setup import configure_logging
+from id4_common.utils.logging_helper import setup_logging
 
-configure_logging()
+setup_logging()

--- a/src/id4_raman/__init__.py
+++ b/src/id4_raman/__init__.py
@@ -5,6 +5,6 @@ This package provides a demo instrument implementation
 for testing and development.
 """
 
-from apsbits.utils.logging_setup import configure_logging
+from id4_common.utils.logging_helper import setup_logging
 
-configure_logging()
+setup_logging()

--- a/tests/test_experiment_utils.py
+++ b/tests/test_experiment_utils.py
@@ -379,119 +379,46 @@ def test_resume_missing_file_no_raise(tmp_path, fresh_experiment, caplog):
     assert "No saved experiment state" in caplog.text
 
 
-# resume() default path discovery --------------------------------------
+# resume() default RE.md restore ---------------------------------------
 
 
-def _write_snapshot(directory, sample="DiscoveredSample"):
-    """Drop a minimal valid snapshot in ``directory`` and return the path."""
-    import yaml as _yaml
-    from id4_common.utils.experiment_utils import PERSIST_FILENAME
-
-    path = directory / PERSIST_FILENAME
-    path.write_text(
-        _yaml.safe_dump(
-            {
-                "esaf_id": 1,
-                "proposal_id": 2,
-                "server": "dserv",
-                "experiment_name": "polar-discovery",
-                "sample": sample,
-                "file_base_name": "scan",
-                "base_experiment_path": str(directory),
-                "last_scan_id": 3,
-            }
-        )
-    )
-    return path
-
-
-def test_resume_discovers_cwd_snapshot(monkeypatch, tmp_path, fresh_experiment):
-    """resume() with no args picks up a snapshot sitting in cwd."""
+def test_resume_default_reads_re_md(monkeypatch, fresh_experiment):
+    """resume() with no args restores from RE.md, not the YAML."""
     exp, _, _ = fresh_experiment
-    _write_snapshot(tmp_path, sample="FromCwd")
+    from id4_common.utils.run_engine import RE
 
-    monkeypatch.setattr(
-        "id4_common.utils.experiment_utils.Path.cwd", lambda: tmp_path
+    RE.md.update(
+        {
+            "esaf_id": "12345",
+            "proposal_id": "67890",
+            "server": "dserv",
+            "experiment_name": "polar-test",
+            "sample": "MySample",
+            "base_name": "scan",
+            "base_experiment_path": "/tmp/restore_test",
+            "scan_id": 47,
+        }
     )
     monkeypatch.setattr(exp, "setup_path", lambda: None)
     monkeypatch.setattr(exp, "start_specwriter", lambda: None)
 
     exp.resume()
-    assert exp.sample == "FromCwd"
+
+    assert exp.experiment_name == "polar-test"
+    assert exp.sample == "MySample"
+    assert exp.file_base_name == "scan"
+    assert exp.base_experiment_path == Path("/tmp/restore_test")
+    assert RE.md["scan_id"] == 47  # untouched
 
 
-def test_resume_discovers_via_cat_when_cwd_empty(
-    monkeypatch, tmp_path, fresh_experiment
-):
-    """When cwd has no snapshot, fall back to cat[-1]'s base_experiment_path."""
+def test_resume_default_no_state_warns(fresh_experiment, caplog):
+    """resume() with no args and empty RE.md logs a warning, doesn't raise."""
+    import logging
+
     exp, _, _ = fresh_experiment
-    cwd_dir = tmp_path / "empty_cwd"
-    cwd_dir.mkdir()
-    cat_dir = tmp_path / "experiment_dir"
-    cat_dir.mkdir()
-    _write_snapshot(cat_dir, sample="FromCat")
-
-    monkeypatch.setattr(
-        "id4_common.utils.experiment_utils.Path.cwd", lambda: cwd_dir
-    )
-
-    fake_run = MagicMock()
-    fake_run.metadata = {"start": {"base_experiment_path": str(cat_dir)}}
-    from id4_common.utils.run_engine import cat as cat_stub
-
-    cat_stub.__getitem__ = MagicMock(return_value=fake_run)
-
-    monkeypatch.setattr(exp, "setup_path", lambda: None)
-    monkeypatch.setattr(exp, "start_specwriter", lambda: None)
-
-    exp.resume()
-    assert exp.sample == "FromCat"
-
-
-def test_resume_prompts_when_both_exist_and_differ(
-    monkeypatch, tmp_path, fresh_experiment
-):
-    """When both candidates exist and differ, ask the user which to use."""
-    exp, prompts, _ = fresh_experiment
-    cwd_dir = tmp_path / "cwd"
-    cwd_dir.mkdir()
-    cat_dir = tmp_path / "cat"
-    cat_dir.mkdir()
-    _write_snapshot(cwd_dir, sample="FromCwd")
-    _write_snapshot(cat_dir, sample="FromCat")
-
-    monkeypatch.setattr(
-        "id4_common.utils.experiment_utils.Path.cwd", lambda: cwd_dir
-    )
-
-    fake_run = MagicMock()
-    fake_run.metadata = {"start": {"base_experiment_path": str(cat_dir)}}
-    from id4_common.utils.run_engine import cat as cat_stub
-
-    cat_stub.__getitem__ = MagicMock(return_value=fake_run)
-
-    monkeypatch.setattr(exp, "setup_path", lambda: None)
-    monkeypatch.setattr(exp, "start_specwriter", lambda: None)
-
-    prompts.append("2")  # pick the cat candidate
-    exp.resume()
-    assert exp.sample == "FromCat"
-
-
-def test_resume_no_args_no_snapshot_anywhere(
-    monkeypatch, tmp_path, fresh_experiment, caplog
-):
-    """resume() with nothing to load logs a warning, doesn't raise."""
-    exp, _, _ = fresh_experiment
-    monkeypatch.setattr(
-        "id4_common.utils.experiment_utils.Path.cwd", lambda: tmp_path
-    )
-    from id4_common.utils.run_engine import cat as cat_stub
-
-    cat_stub.__getitem__ = MagicMock(side_effect=IndexError)
-
-    exp.resume()
-    assert "No experiment snapshot found" in caplog.text
+    with caplog.at_level(logging.WARNING):
+        exp.resume()
+    assert "No prior experiment found in RE.md" in caplog.text
 
 
 # experiment_path properties --------------------------------------------


### PR DESCRIPTION
Closes #20.
Closes #40.
Closes #43.
Closes #44.
Closes #51.

Bundle of five issue fixes plus a related `load_vortex` cleanup. Each issue lives on its own commit so the history can be cherry-picked or reverted individually if needed.

## #20 — SPEC writer output unparseable for qxscan / array metadata

`pymca` rejected polar-bits SPEC files for two distinct reasons that surface together on `qxscan`:

1. `write_scan_header` formatted `#MD k = v` directly via f-string. When `v` was a numpy array (or a list/dict containing one), its repr line-wraps, and every continuation line landed in the file with no leading `#`. pymca treats those as malformed.
2. `_rebuild_scan_command.get_name` fell through to `str(src)` for any positional arg without a `name=` repr, so qxscan's energy/time numpy arrays were inlined verbatim into the `#S` line — yielding a single line that pymca cannot parse as a scan command.

**Fix.** Added an `_one_line(v)` helper that collapses any whitespace (incl. newlines) in metadata values to single spaces; for numpy arrays it uses `np.array2string(..., max_line_width=10**9)` to avoid the wrapping in the first place. Applied in `write_scan_header` (#MD), `write_scan_data_row` (#U remarks), and `write_scan_end` (#C). Separately, `get_name` now returns a compact `<array len=N>` / `<list len=N>` / `<tuple len=N>` summary for non-ophyd sequence args; the full data is still preserved (on a single line) in `#MD plan_args`.

**Verified** end-to-end by simulating a qxscan document stream with 60-point arrays — `#S` line drops to ~100 chars and the file contains no bare (non-`#`) lines.

## #40 — No way to clear all energy tracking from the interactive prompt

`energy.tracking_setup()`'s prompt rejected `0`, so disabling tracking on every device required either passing an empty list (which re-triggered the prompt) or untracking each device by hand.

**Fix.** `_tracking_prompts` accepts `0` as the "disable tracking on every device" sentinel. When `0` appears alongside other indices, `0` wins (the safer choice). The prompt label and a header line above the menu both advertise the option so it's discoverable. Doc example in `docs/source/examples/general.md` updated.

## #43 — `load_device` skipped already-registered devices

`load_device(name)` returned early with a warning whenever the device was already in `oregistry`, telling users to call `connect_device` directly. After a flaky IOC connection users had to remember which helper to call.

**Fix.** `load_device` now checks `oregistry.find(name, allow_none=True)` and, if the device is registered, fetches the existing object and routes it through `connect_device(..., raise_error=False)`. The not-yet-loaded path is unchanged. `load_device("foo")` is now the single canonical entry point for "make sure foo is loaded and connected," whether it's the first attempt or a retry.

## #44 — Several area detectors never primed `hdf1`

`connect_device` already calls `AD_prime_plugin2(device.hdf1)` after `default_settings()`, which fires `hdf1.warmup()` when the plugin has never received an array. The warmup walks `hdf1.warmup_signals` (the list of `(signal, value)` pairs that briefly trigger one acquisition), but four detector classes never populated that list — so their HDF1 plugins were never primed and the first scan after a fresh IOC start would fail at the staging step.

**Fix.** Added `self.hdf1.warmup_signals = [...]` to each `default_settings()`:

- `Lambda250kDetector` and the two `VortexXspress3*` classes: ADCore pattern (enable + array_callbacks + image_mode (Single) + trigger_mode (Internal) + acquire_time + acquire), copying the existing Eiger/Vimba reference.
- `VortexDante1` and `VortexDante4`: Dante doesn't expose an ADCore `acquire` signal, so they use the MCA-mode pattern (enable + array_callbacks + mca_mode (MCA) + real_time_preset (0.1s) + acquire_start). A short comment in each file explains why it differs.

⚠️ **Smoke test wanted at the beamline.** I couldn't drive real IOCs from a dev machine, so the Dante warmup_signals in particular may need tweaking — please verify priming actually fires on the first acquisition.

## #51 — Bluesky logs scattered across whatever directory ipython was started in

Each beamline's `__init__.py` called `apsbits.utils.logging_setup.configure_logging()` with no arguments, which loads only apsbits' default `logging.yml` and points the file handler at `<cwd>/.logs/`. The `LOGGING` block already in `iconfig.yml` looked wired up but apsbits never read it — `configure_logging` only consumes its own `configs/logging.yml` plus an optional override path, not iconfig keys.

**Fix.** Made the iconfig block the actual source of truth:

- New `id4_common.utils.logging_helper.setup_logging()` reads the `LOGGING` block from `iconfig.yml`, translates POLAR-friendly keys (`LOG_PATH`, `MAX_BYTES`, `NUMBER_OF_PREVIOUS_BACKUPS`) into the apsbits `file_logs` / `ipython_logs` schema, dumps it to a temp YAML, and passes the path to `configure_logging(extra_logging_configs_path=...)`. Temp file is unlinked in a `finally`.
- All five beamline `__init__.py` files now call `setup_logging()` instead of `configure_logging()` directly, so every entry point uses the same path.
- The `LOGGING` comment in `iconfig.yml` is rewritten to describe the actual flow. Unset / unwritable `LOG_PATH` falls back to `<cwd>/.logs/` (catches `(PermissionError, OSError)` from `configure_logging` and re-runs without the override). Verified the fallback on a Mac where `/net/...` isn't reachable.

To add a new POLAR-friendly key later, extend `_FILE_LOGS_KEY_MAP` in `logging_helper.py`.

## Follow-up — `load_vortex` parity with `load_device`

Three inconsistencies, all surfaced by working through #43/#44:

1. `load_vortex`'s docstring promised the device would always be added to `__main__`, but the `setattr(sys.modules["__main__"], name, device)` call lived inside the connect try-block. A `TimeoutError` skipped the assignment and left the user with no handle on the device object.
2. It did not call `_post_connect_setup`, did not set up cam `wait_for_plugins`/`blocking_callbacks` stage_sigs, and did not prime `hdf1` — all things `load_device` gets free via `connect_device`. With #44's warmup_signals in place, vortex detectors loaded via `load_vortex` would still have skipped priming.
3. Latent bug: the dante-only "set vortex._local_folder" hint was built into a `message` variable inside an `if "dante" in ...:` branch, but `logger.warning(message)` ran for every electronics type — `NameError` on the first non-dante load in a fresh session.

**Fix.** `load_vortex` now delegates connect / register / baseline / hdf1-prime to `connect_device(device, baseline=baseline, raise_error=False)` and moves the namespace assignment outside the connect path. The dante hint is scoped to the `if "dante"` branch as a single multi-line string so it can't drift again.

## Verification on this branch

- `pre-commit run --all-files`: passes (ruff, ruff-format, end-of-file-fixer, trailing-whitespace, check-yaml/toml/ast).
- `pytest tests/`: 20/20 pass.
- `_one_line` exercised against numpy arrays, multi-line strings, scalars, long lists, dicts.
- Energy `_tracking_prompts` exercised with `"0"`, `"1 3"`, `"0 2"` inputs (clears all, sets indexed, `0` wins on conflict).
- Logging fallback exercised on a Mac (write to `/net/...` fails → handler ends up on `<cwd>/.logs/`).
- Simulated qxscan SPEC file: 60-point energy/time arrays produce a 100-char `#S` line and no bare lines anywhere in the output.

## Things I could not verify

- Real IOC behaviour for any of the camera warmup_signals in #44 — please smoke test, especially Dante.
- Real beamline filesystem availability for `/net/s4data/export/sector4/4idd/bluesky_logs` (#51) — fallback works, but it would be worth confirming the path is actually writable from a beamline machine and that the directory layout matches what staff expect.

## Commit layout

| Commit | Issue / topic |
|--------|---------------|
| `e194c12` | #20 SPEC writer (qxscan + array metadata) |
| `da57fb0` | #40 energy tracking `0` option |
| `5ecb372` | #43 load_device reconnect |
| `a77a89d` | #44 camera HDF1 warmup_signals |
| `bcb6740` | #51 centralized bluesky logs |
| `50378db` | `load_vortex` parity follow-up |
| `efba23c` | CLAUDE.md docs catching up to all of the above |

🤖 Generated with [Claude Code](https://claude.com/claude-code)