### PR TITLE
Easier macros: macros_api + recoverable session_state + undulator_setup cleanup (#18)

### DIFF
--- a/docs/source/examples/macros/align_routine.py
+++ b/docs/source/examples/macros/align_routine.py
@@ -1,0 +1,61 @@
+"""
+Sample-alignment routine modelled after a real beamline macro.
+
+Scans the table x and y motors of the 9-T magnet stage, centers on the
+absorption peak via :func:`cen`, and offers a ``check_position`` retry
+loop that re-runs the alignment until the position settles within a
+tolerance.  Lift the patterns straight into your own macro.
+"""
+
+from bluesky.plan_stubs import sleep
+from id4_common.macros.macros_api import *  # noqa: F401, F403
+
+magnet = oregistry.find("magnet911")  # noqa: F405
+energy = oregistry.find("energy")  # noqa: F405
+
+
+def align_x(start=-0.015, end=0.015, npts=60, dwell=0.2):
+    """Scan tab.x and move to the FWHM midpoint."""
+    yield from lup(magnet.tab.x, start, end, npts, dwell)  # noqa: F405
+    yield from cen(magnet.tab.x)  # noqa: F405
+
+
+def align_y(start=-0.015, end=0.015, npts=60, dwell=0.2):
+    """Scan tab.y and move to the FWHM midpoint."""
+    yield from lup(magnet.tab.y, start, end, npts, dwell)  # noqa: F405
+    yield from cen(magnet.tab.y)  # noqa: F405
+
+
+def align_xy(start=-0.015, end=0.015):
+    """Run align_x then align_y at the current energy."""
+    yield from align_x(start, end)
+    yield from align_y(start, end)
+
+
+def check_position(tolerance=0.001, wait_time=30, max_tries=10):
+    """Re-align until x and y stop moving by more than ``tolerance``.
+
+    Useful when the sample is drifting (e.g. after a field ramp).  Sleeps
+    ``wait_time`` between attempts and gives up after ``max_tries``.
+    """
+    xi = magnet.tab.x.position
+    yi = magnet.tab.y.position
+
+    for i in range(max_tries):
+        yield from align_xy()
+        xn = magnet.tab.x.position
+        yn = magnet.tab.y.position
+
+        print(f"\n attempt #{i + 1}")
+        print(f"   x: {xi:.5f} -> {xn:.5f}  (dx = {xn - xi:+.5f})")
+        print(f"   y: {yi:.5f} -> {yn:.5f}  (dy = {yn - yi:+.5f})")
+
+        if abs(xn - xi) < tolerance and abs(yn - yi) < tolerance:
+            print("   settled.")
+            return
+
+        xi, yi = xn, yn
+        print(f"   sleeping {wait_time} s before re-trying...")
+        yield from sleep(wait_time)
+
+    print(f"max_tries={max_tries} hit without settling.")

--- a/docs/source/examples/macros/field_sequence.py
+++ b/docs/source/examples/macros/field_sequence.py
@@ -1,0 +1,49 @@
+"""
+Overnight field-dependent XMCD sequence on the 9-T magnet (4-ID-H).
+
+Pattern: ramp the magnet to a target, settle, re-align (the field
+ramp shifts the sample), measure XMCD at L2 and L3, then ramp the
+field through the negative polarity and repeat.  Designed to be
+``RE(overnight_field_sweep([3.0, -3.0]))``-able.
+"""
+
+from bluesky.plan_stubs import sleep
+from id4_common.macros.macros_api import *  # noqa: F401, F403
+
+# Adjust if you split align_routine / xmcd_at_two_edges into your own
+# files; pulling them in by name keeps this script self-documenting.
+from .align_routine import align_xy, check_position  # noqa: F401
+from .xmcd_at_two_edges import measure_xmcd, move_to_edge  # noqa: F401
+
+magnet = oregistry.find("magnet911")  # noqa: F405
+
+
+def settle_at_field(target, settle_seconds=300):
+    """Ramp to ``target`` Tesla and wait for the field to stabilise."""
+    yield from mv(magnet.ps.field, target)  # noqa: F405
+    print(f"Field at {target} T; settling for {settle_seconds} s.")
+    yield from sleep(settle_seconds)
+
+
+def field_point(field, num_per_edge=5, dwell=5, edges=("L2", "L3")):
+    """One field point: settle, re-align, measure at every edge in ``edges``."""
+    yield from settle_at_field(field)
+    yield from align_xy(-0.2, 0.2)
+    yield from check_position(tolerance=0.0005, wait_time=60, max_tries=20)
+
+    for name in edges:
+        yield from move_to_edge(name)
+        yield from measure_xmcd(
+            name,
+            num=num_per_edge,
+            time=dwell,
+            align_first=True,
+            align_plan=align_xy,
+        )
+
+
+def overnight_field_sweep(targets, num_per_edge=9, dwell=5):
+    """Visit every field in ``targets``; finish back at zero field."""
+    for f in targets:
+        yield from field_point(f, num_per_edge=num_per_edge, dwell=dwell)
+    yield from mv(magnet.ps.field, 0)  # noqa: F405

--- a/docs/source/examples/macros/hkl_map.py
+++ b/docs/source/examples/macros/hkl_map.py
@@ -1,0 +1,47 @@
+"""
+HKL map + center on a Bragg peak.
+
+For a known peak around (h0, k0, l0), runs a small ``hklscan`` sweep
+along H, then ``cen(h)`` to refine the H position.  Repeats for K and L
+to lock down the orientation in three quick scans.
+"""
+
+from id4_common.macros.macros_api import *  # noqa: F401, F403
+
+
+def refine_hkl(h0, k0, l0, half_window=0.05, npts=51, dwell=0.5):
+    """Scan h/k/l one at a time around (h0, k0, l0) and center on each."""
+    yield from hscan(  # noqa: F405
+        h0 - half_window, h0 + half_window, npts, dwell
+    )
+    yield from cen(positioner=oregistry.find("h"))  # noqa: F405
+
+    yield from kscan(  # noqa: F405
+        k0 - half_window, k0 + half_window, npts, dwell
+    )
+    yield from cen(positioner=oregistry.find("k"))  # noqa: F405
+
+    yield from lscan(  # noqa: F405
+        l0 - half_window, l0 + half_window, npts, dwell
+    )
+    yield from cen(positioner=oregistry.find("l"))  # noqa: F405
+
+
+def hkl_grid_map(h0, k0, l0, span=0.05, npts=21, dwell=0.5):
+    """2-D ``hklscan`` from (h-span, k0, l0) to (h+span, k+span, l0).
+
+    Uses :func:`hklscan` which sweeps the three pseudo axes along a
+    straight line in reciprocal space.  After the scan, run
+    ``RE(cen())`` from the prompt to move to the FWHM midpoint of the
+    largest-range axis.
+    """
+    yield from hklscan(  # noqa: F405
+        h0 - span,
+        h0 + span,
+        k0,
+        k0 + span,
+        l0,
+        l0,
+        npts,
+        dwell,
+    )

--- a/docs/source/examples/macros/qxscan_chain.py
+++ b/docs/source/examples/macros/qxscan_chain.py
@@ -1,0 +1,43 @@
+"""
+Chain ``qxscan`` over a list of edges.
+
+The qxscan plan handles one absorption edge at a time.  This script
+shows two related patterns:
+
+- ``qxscan_chain`` — iterate over an explicit list of (label, energy)
+  pairs.  Pass ``lockin=True`` for XMCD-style scans.
+- ``qxscan_setup_then_run`` — interactively reconfigure the
+  ``qxscan_setup`` device's pre/edge/post regions before running.
+"""
+
+from id4_common.macros.macros_api import *  # noqa: F401, F403
+
+qxscan_setup = oregistry.find("qxscan_setup")  # noqa: F405
+
+EDGES = [
+    ("Tb_L3", 7.515),
+    ("Tb_L2", 8.253),
+]
+
+
+def qxscan_chain(time=5, lockin=False, edges=EDGES, num=1):
+    """Run ``num`` qxscans at every (label, energy) pair in ``edges``."""
+    for label, energy_keV in edges:
+        for _ in range(num):
+            print(f"\n=== qxscan @ {label} ({energy_keV} keV) ===")
+            yield from qxscan(  # noqa: F405
+                energy_keV, time, lockin=lockin
+            )
+
+
+def qxscan_setup_then_run(label, energy_keV, time=5, lockin=False):
+    """Re-prompt ``qxscan_setup`` then run one qxscan at the given edge.
+
+    The interactive call regenerates ``qxscan_setup.energy_list`` /
+    ``factor_list`` from the current pre/edge/post regions, so this is
+    the right entry point when you want to change the scan grid before
+    measuring.
+    """
+    qxscan_setup()
+    print(f"\n=== qxscan @ {label} ({energy_keV} keV) ===")
+    yield from qxscan(energy_keV, time, lockin=lockin)  # noqa: F405

--- a/docs/source/examples/macros/startup.py
+++ b/docs/source/examples/macros/startup.py
@@ -1,0 +1,44 @@
+"""
+Session-restart template — recoverable startup macro.
+
+Use this when bluesky needs to be restarted mid-experiment::
+
+    %run startup.py
+
+Restores the per-experiment knobs (undulator offsets / deadbands,
+energy tracking selection, ``pr_setup``, ``counters.plotselect``,
+qxscan setup) that were auto-saved into ``RE.md["session_state"]`` by
+the regular setup helpers (``pr_setup``, ``energy.tracking_setup``,
+``counters.plotselect``, ``undulator_setup``,
+``qxscan_setup.load_params_json``).
+
+Anything not auto-saved (vortex electronics choice, custom motor
+shortcuts, …) goes below the ``# --- hand-set after this line ---``
+marker so a future restart still picks it up.
+"""
+
+from matplotlib import pyplot as plt
+
+from id4_common.macros.macros_api import *  # noqa: F401, F403
+from id4_common.utils.experiment_utils import experiment_load_from_bluesky
+from id4_common.utils.session_state import restore_session_state
+
+plt.ion()  # interactive plots
+
+experiment_load_from_bluesky()  # restores experiment metadata from cat[-1]
+
+status = restore_session_state()
+print("\nSession-state restore:")
+for knob, msg in status.items():
+    print(f"  {knob:18}  {msg}")
+
+
+# --- hand-set after this line --------------------------------------------
+#
+# Things that aren't (yet) auto-saved into RE.md.  Edit per experiment.
+
+# vortex = load_vortex("xspress4")
+# vortex.auto_save_on()
+# vortex._sleep_after_trigger = 0.1
+
+# from motor_shortcuts import *

--- a/docs/source/examples/macros/xmcd_at_two_edges.py
+++ b/docs/source/examples/macros/xmcd_at_two_edges.py
@@ -1,0 +1,70 @@
+"""
+XMCD measurement at two absorption edges (e.g. Tb L3 / L2).
+
+Shows two patterns:
+
+- ``move_to_edge`` — group the energy + analyzer + preamp moves needed
+  to switch between two edges in one yield-from.
+- ``measure_xmcd`` — wrap a small sequence (optional alignment + N
+  averaged ``qxscan`` runs) so callers can do
+  ``RE(measure_xmcd("L3", num=5))`` or chain it from a longer plan.
+"""
+
+from id4_common.macros.macros_api import *  # noqa: F401, F403
+
+energy = oregistry.find("energy")  # noqa: F405
+pr2 = oregistry.find("pr2")  # noqa: F405
+preamp_i = oregistry.find("preamp_4idhI1")  # noqa: F405
+
+
+# Each entry: (energy in keV, pr2 PZT offset in deg, qxscan edge in keV,
+# preamp sensitivity value, preamp sensitivity unit).
+EDGES = {
+    "L3": (7.520, 0.012, 7.515, "2", "uA/V"),
+    "L2": (8.255, 0.009, 8.253, "5", "uA/V"),
+}
+
+
+def move_to_edge(name):
+    """Move energy + PR2 phase + preamp gain to one of the named edges."""
+    e, pzt_offset, _, sens_value, sens_unit = EDGES[name]
+    yield from mv(  # noqa: F405
+        energy,
+        e,
+        pr2.pzt.offset_degrees,
+        pzt_offset,
+    )
+    yield from mv(  # noqa: F405
+        preamp_i.sensitivity_value,
+        sens_value,
+        preamp_i.sensitivity_unit,
+        sens_unit,
+    )
+    yield from mv(preamp_i.set_all, 1)  # noqa: F405
+
+
+def measure_xmcd(edge, num=1, time=1, align_first=False, align_plan=None):
+    """Measure ``num`` averaged qxscans at ``edge``.
+
+    If ``align_first`` is True, calls ``align_plan`` (defaults to your
+    own ``align_xy()`` from align_routine.py) before each scan.
+    """
+    _, _, edge_energy, _, _ = EDGES[edge]
+    for _ in range(num):
+        if align_first and align_plan is not None:
+            yield from align_plan()
+        yield from qxscan(  # noqa: F405
+            edge_energy, time, lockin=True
+        )
+
+
+def xmcd_l2_l3(num=5, time=1, align_first=False, align_plan=None):
+    """Convenience: measure num scans at L2 then num scans at L3."""
+    yield from move_to_edge("L2")
+    yield from measure_xmcd(
+        "L2", num=num, time=time, align_first=align_first, align_plan=align_plan
+    )
+    yield from move_to_edge("L3")
+    yield from measure_xmcd(
+        "L3", num=num, time=time, align_first=align_first, align_plan=align_plan
+    )

--- a/docs/source/examples/writing_macros.md
+++ b/docs/source/examples/writing_macros.md
@@ -136,15 +136,21 @@ from motor_shortcuts import *
 
 Bluesky plans are Python generator functions. They use `yield from` to compose
 built-in plan stubs, which allows the RunEngine to track, pause, and replay
-them. Any sequence of moves and scans can be wrapped in a plan:
+them. Any sequence of moves and scans can be wrapped in a plan.
+
+**Use `id4_common.macros.macros_api`** as the single import line for every
+plan/peak/setting helper your macro needs (issue #18). It re-exports every
+public scan plan (`ascan`, `lup`, `mv`, `mvr`, `grid_scan`, `rel_grid_scan`,
+`hklscan`, `qxscan`, …), every peak-finding plan (`cen` / `com` / `maxi` /
+`mini` plus the legacy `cen2` / `maxi2` / `mini2`), and the session-level
+singletons (`oregistry`, `counters`, `peaks`, `atten`). The list is curated
+and kept stable across internal package reorgs — your macros stay working
+when modules move around inside `id4_common`.
 
 ```python
 # macros.py
 from bluesky.plan_stubs import abs_set, sleep
-from id4_common.plans.local_scans import lup, ascan, mv, grid_scan, rel_grid_scan
-from id4_common.plans.center_maximum import cen
-from id4_common.utils.counters_class import counters
-from apsbits.core.instrument_init import oregistry
+from id4_common.macros.macros_api import *
 
 huber_hp = oregistry.find("huber_hp")
 energy   = oregistry.find("energy")
@@ -171,6 +177,23 @@ def energy_map(energies, dwell=0.5):
             snake_axes=True,
         )
 ```
+
+**Bluesky stubs are not re-exported** from `macros_api` — keep
+`from bluesky.plan_stubs import abs_set, rd, sleep, ...` as a separate
+explicit import so the bluesky surface stays visible.
+
+Five real-world macro templates live under `docs/source/examples/macros/`
+and follow this pattern:
+
+| File | What it shows |
+|------|---------------|
+| `align_routine.py` | tab.x / tab.y alignment + `check_position` retry loop |
+| `xmcd_at_two_edges.py` | per-edge energy + PR2 + preamp swap, then averaged qxscans |
+| `field_sequence.py` | overnight field sweep that re-aligns after every ramp |
+| `qxscan_chain.py` | iterate `qxscan` over a list of edges |
+| `hkl_map.py` | `hklscan` + `cen` to refine a Bragg peak |
+
+Copy any of them into your experiment directory and edit to taste.
 
 Run a plan:
 

--- a/docs/source/examples/writing_macros.md
+++ b/docs/source/examples/writing_macros.md
@@ -182,7 +182,7 @@ def energy_map(energies, dwell=0.5):
 `from bluesky.plan_stubs import abs_set, rd, sleep, ...` as a separate
 explicit import so the bluesky surface stays visible.
 
-Five real-world macro templates live under `docs/source/examples/macros/`
+Six real-world macro templates live under `docs/source/examples/macros/`
 and follow this pattern:
 
 | File | What it shows |
@@ -192,8 +192,31 @@ and follow this pattern:
 | `field_sequence.py` | overnight field sweep that re-aligns after every ramp |
 | `qxscan_chain.py` | iterate `qxscan` over a list of edges |
 | `hkl_map.py` | `hklscan` + `cen` to refine a Bragg peak |
+| `startup.py` | recoverable session start — calls `restore_session_state()` |
 
 Copy any of them into your experiment directory and edit to taste.
+
+### Recoverable session state
+
+The setup helpers (`pr_setup`, `energy.tracking_setup`,
+`counters.plotselect`, `undulator_setup`,
+`qxscan_setup.load_params_json`) auto-snapshot their current values into
+`RE.md["session_state"]` — apsbits' `PersistentDict` backed by `MD_PATH`
+(`iconfig.yml`).  After a bluesky restart, call
+`restore_session_state()` to re-apply every saved knob in one go.  See
+`docs/source/examples/macros/startup.py` for the canonical recoverable
+startup template.
+
+```python
+from id4_common.utils.session_state import restore_session_state
+status = restore_session_state()
+for knob, msg in status.items():
+    print(f"  {knob:18}  {msg}")
+```
+
+`status` reports `applied` / `skipped: <reason>` / `failed: <Exception>`
+per knob group — restore never raises, a missing device or single
+failed `.put()` is logged and the rest of the restore continues.
 
 Run a plan:
 

--- a/docs/source/examples/writing_macros.md
+++ b/docs/source/examples/writing_macros.md
@@ -42,7 +42,27 @@ with `%run`:
 %run startup_4idh.py
 ```
 
-A typical session startup file looks like this:
+### Quick path: the prebuilt restart helper
+
+For a session restart inside an experiment that has already been set up
+once, the package ships a single import that does the whole restore:
+
+```python
+import id4_common.macros.startup_common  # noqa: F401
+```
+
+That one line calls `experiment_resume()` (auto-discovers the snapshot
+in the current directory or via `cat[-1]`) followed by
+`restore_session_state()` (re-applies every auto-saved setup knob — see
+[Recoverable session state](#recoverable-session-state)) and prints a
+per-knob status summary. `restore_session_state` is also imported into
+the interactive session namespace by `_common_startup.py`, so you can
+re-run it on demand without an extra import.
+
+### Full custom startup
+
+When you need more than a restart — first run of an experiment, manual
+overrides, extra devices — write your own startup file:
 
 ```python
 # startup_4idh.py
@@ -80,7 +100,7 @@ pr_setup.offset        = oregistry.find("pr2_pzt_offset_microns")
 pr_setup.oscillate_pzt = True
 
 # Load motor shortcuts and macros
-from motor_shortcuts import *
+import id4_common.macros.shortcuts_4idh_9T  # noqa: F401
 from macros import *
 ```
 
@@ -88,46 +108,55 @@ from macros import *
 
 ## Motor Shortcuts
 
-Create short variable names for frequently used motors by retrieving them
-from the device registry. Put these in a `motor_shortcuts.py` file:
+Create short variable names for frequently used motors so you can type
+`mv field 3` instead of `mv magnet911.ps.field 3`.
+
+### Prebuilt shortcuts (recommended)
+
+The package ships ready-to-go shortcut modules under
+`id4_common.macros` for each common 4-ID setup. Importing the matching
+one binds its motor names directly into the interactive session:
+
+| Module | Setup | Binds |
+|--------|-------|-------|
+| `shortcuts_4idg_euler` | 4IDG Euler diffractometer (`huber_euler`) | `h`, `k`, `l`, `tau`, `mu`, `gamma`, `delta`, `chi`, `phi`, `x`, `y`, `z` |
+| `shortcuts_4idg_hp` | 4IDG HP diffractometer (`huber_hp`) | the Euler set + `basex`/`basey`/`basez` (+ motor variants), `sample_tilt`, `nanox`/`nanoy`/`nanoz`, `xeryon` |
+| `shortcuts_4idh_9T` | 4IDH 9-Tesla magnet (`magnet911`) | `field`, `tabx`, `taby`, `tabz`, `tabsx`, `tabsz`, `tabrot`, `sy`, `sth` |
 
 ```python
-# motor_shortcuts.py — 4IDH example
+import id4_common.macros.shortcuts_4idg_hp  # noqa: F401
+# now: h, k, l, gamma, delta, nanox, ... are directly usable in the session
+```
+
+The import has to come *after* the underlying device is loaded
+(`huber_hp`, `huber_euler`, or `magnet911`) — the shortcut modules
+resolve names against `oregistry` at import time. Each module logs
+`<full_name> --> <short_name>` to the session log so you can see what
+landed.
+
+### Custom shortcuts
+
+For names that aren't covered by the prebuilt set, write your own
+file using the same pattern:
+
+```python
+# motor_shortcuts.py — extra shortcuts for one experiment
 from apsbits.core.instrument_init import oregistry
 
 _mag = oregistry.find("magnet911")
+_huber = oregistry.find("huber_euler")
 
-tabx  = _mag.tab.x       # sample table X
-taby  = _mag.tab.y       # sample table Y
-tabth = _mag.tab.srot    # sample table rotation
-samy  = _mag.samp.y      # sample Y
-samth = _mag.samp.th     # sample rotation
-field = _mag.ps.field    # magnetic field (Tesla)
-```
-
-```python
-# motor_shortcuts.py — 4IDG example
-from apsbits.core.instrument_init import oregistry
-
-huber_euler = oregistry.find("huber_euler")
-huber_hp    = oregistry.find("huber_hp")
-energy      = oregistry.find("energy")
-
-sx  = huber_euler.x
-sy  = huber_euler.y
-phi = huber_euler.phi
-chi = huber_euler.chi
-delta = huber_euler.delta
-
-nanox = huber_hp.nanox
-nanoy = huber_hp.nanoy
+samy   = _mag.samp.y
+samth  = _mag.samp.th
+energy = oregistry.find("energy")
+sx     = _huber.x
 ```
 
 Import with a wildcard so shortcuts land in the session namespace:
 
 ```python
 from motor_shortcuts import *
-# now: tabx, field, phi, etc. are directly usable
+# now: samy, samth, energy, sx are directly usable
 ```
 
 ---
@@ -192,7 +221,7 @@ and follow this pattern:
 | `field_sequence.py` | overnight field sweep that re-aligns after every ramp |
 | `qxscan_chain.py` | iterate `qxscan` over a list of edges |
 | `hkl_map.py` | `hklscan` + `cen` to refine a Bragg peak |
-| `startup.py` | recoverable session start — calls `restore_session_state()` |
+| `startup.py` | recoverable session start template — `experiment_load_from_bluesky()` fallback + per-experiment hand-managed steps. Use this when you outgrow the in-package one-liner `id4_common.macros.startup_common`. |
 
 Copy any of them into your experiment directory and edit to taste.
 
@@ -203,16 +232,23 @@ The setup helpers (`pr_setup`, `energy.tracking_setup`,
 `qxscan_setup.load_params_json`) auto-snapshot their current values into
 `RE.md["session_state"]` — apsbits' `PersistentDict` backed by `MD_PATH`
 (`iconfig.yml`).  After a bluesky restart, call
-`restore_session_state()` to re-apply every saved knob in one go.  See
-`docs/source/examples/macros/startup.py` for the canonical recoverable
-startup template.
+`restore_session_state()` to re-apply every saved knob in one go.
+`_common_startup.py` already imports it, so it's directly available in
+the session:
 
 ```python
-from id4_common.utils.session_state import restore_session_state
 status = restore_session_state()
 for knob, msg in status.items():
     print(f"  {knob:18}  {msg}")
 ```
+
+For a one-line restart that runs `experiment_resume()` first and prints
+the per-knob summary itself, use the prebuilt
+`id4_common.macros.startup_common` module shown in the [Quick path
+section](#quick-path-the-prebuilt-restart-helper).
+`docs/source/examples/macros/startup.py` is a longer template with the
+full `experiment_load_from_bluesky()` fallback and additional
+hand-managed steps (e.g. `load_vortex`).
 
 `status` reports `applied` / `skipped: <reason>` / `failed: <Exception>`
 per knob group — restore never raises, a missing device or single

--- a/src/id4_common/_common_startup.py
+++ b/src/id4_common/_common_startup.py
@@ -136,6 +136,7 @@ else:
     from id4_common.utils.oregistry_auxiliar import get_devices  # noqa: F401
     from id4_common.utils.polartools_hklpy2_imports import *  # noqa: F403
     from id4_common.utils.utilities import *  # noqa: F403
+    from id4_common.utils.session_state import restore_session_state  # noqa: F403
 
 # Use only the A shutter suspender, but the B shutter is still there.
 RE.install_suspender(shutter_suspenders["a_shutter"])

--- a/src/id4_common/_common_startup.py
+++ b/src/id4_common/_common_startup.py
@@ -135,8 +135,10 @@ else:
     from id4_common.utils.logbook_mcr import *  # noqa: F403
     from id4_common.utils.oregistry_auxiliar import get_devices  # noqa: F401
     from id4_common.utils.polartools_hklpy2_imports import *  # noqa: F403
+    from id4_common.utils.session_state import (
+        restore_session_state,  # noqa: F401
+    )
     from id4_common.utils.utilities import *  # noqa: F403
-    from id4_common.utils.session_state import restore_session_state  # noqa: F403
 
 # Use only the A shutter suspender, but the B shutter is still there.
 RE.install_suspender(shutter_suspenders["a_shutter"])

--- a/src/id4_common/devices/energy_device.py
+++ b/src/id4_common/devices/energy_device.py
@@ -144,6 +144,15 @@ class EnergySignal(Signal):
                 flag = True if name in devices_names else False
                 device.tracking.put(flag)
 
+        # Auto-save the new tracking selection so a bluesky restart can
+        # re-apply it via session_state.restore_session_state().
+        try:
+            from ..utils.session_state import _save_energy_tracking
+
+            _save_energy_tracking()
+        except Exception:  # noqa: BLE001
+            pass
+
     def _tracking_prompts(self):
         _ = self.tracking
         print("=== Enter 0 to disable tracking on all devices ===")

--- a/src/id4_common/devices/qxscan_device.py
+++ b/src/id4_common/devices/qxscan_device.py
@@ -249,6 +249,15 @@ class QxscanParams(Device):
 
         self._create_positions_list()
 
+        # Auto-save inline params for restore_session_state().  Lazy
+        # import keeps the module-load order safe.
+        try:
+            from ..utils.session_state import _save_qxscan
+
+            _save_qxscan()
+        except Exception:  # noqa: BLE001
+            pass
+
     def _create_positions_list(self):
         elist = []
         factorlist = []
@@ -437,6 +446,16 @@ class QxscanParams(Device):
         """
         input = json.load(open(fname, "r"))
         self._read_params_dict(input)
+
+        # Record the source file for restore_session_state().  Storing
+        # the path keeps the snapshot small (no need to dump every
+        # region into RE.md).
+        try:
+            from ..utils.session_state import _save_qxscan
+
+            _save_qxscan(source=fname)
+        except Exception:  # noqa: BLE001
+            pass
 
     def load_from_scan(self, scan, cat=cat):
         """

--- a/src/id4_common/macros/__init__.py
+++ b/src/id4_common/macros/__init__.py
@@ -1,0 +1,7 @@
+"""User-facing macro helpers (issue #18).
+
+This package is the curated surface that user macro files import from,
+so internal reorgs in ``id4_common`` don't ripple into beamline scripts.
+The single canonical entry point is :mod:`id4_common.macros.macros_api`;
+other helpers will be added here over time.
+"""

--- a/src/id4_common/macros/macros_api.py
+++ b/src/id4_common/macros/macros_api.py
@@ -1,0 +1,108 @@
+"""
+Single-import surface for user macro files (issue #18).
+
+::
+
+    from id4_common.macros.macros_api import *
+
+Re-exports every public scan plan, every move plan, the peak-finding
+plans, and the session-level singletons (counters, oregistry, peaks,
+atten).  The list is **curated and stable across internal package
+reorgs** — macro files keep working when we move things around inside
+``id4_common``.
+
+Bluesky stubs (``abs_set``, ``rd``, ``sleep``, ``trigger_and_read``,
+``move_per_step``, ``null``, …) are not re-exported here on purpose —
+import them explicitly from ``bluesky.plan_stubs`` so the bluesky
+surface stays visible in user macros.
+
+Pattern to copy:
+
+::
+
+    from id4_common.macros.macros_api import *
+    from bluesky.plan_stubs import abs_set, rd, sleep
+
+    energy = oregistry.find("energy")
+    magnet = oregistry.find("magnet911")
+
+    def align_xy(start=-0.015, end=0.015):
+        yield from lup(magnet.tab.x, start, end, 60, 0.2)
+        yield from cen(magnet.tab.x)
+        yield from lup(magnet.tab.y, start, end, 60, 0.2)
+        yield from cen(magnet.tab.y)
+"""
+
+from apsbits.core.instrument_init import oregistry  # noqa: F401
+
+# Polar-bits scan plans (post-#56 split; aliased from the focused modules
+# so user macros never need to know which file each plan lives in).
+from ..plans.base_scans import ascan  # noqa: F401
+from ..plans.base_scans import count  # noqa: F401
+from ..plans.base_scans import lup  # noqa: F401
+from ..plans.base_scans import qxscan  # noqa: F401
+from ..plans.grid_scans import grid_scan  # noqa: F401
+from ..plans.grid_scans import rel_grid_scan  # noqa: F401
+from ..plans.hkl_scans import hklscan  # noqa: F401
+from ..plans.hkl_scans import hscan  # noqa: F401
+from ..plans.hkl_scans import kscan  # noqa: F401
+from ..plans.hkl_scans import lscan  # noqa: F401
+from ..plans.hkl_scans import psiscan  # noqa: F401
+from ..plans.hkl_scans import th2th  # noqa: F401
+from ..plans.move_plans import mv  # noqa: F401
+from ..plans.move_plans import mvr  # noqa: F401
+
+# Peak-finding plans (the new findpeaks-style cen/com/maxi/mini from #59
+# plus the BEC-driven cen2/maxi2/mini2 fallbacks).
+from ..plans.center_maximum import cen2  # noqa: F401
+from ..plans.center_maximum import maxi2  # noqa: F401
+from ..plans.center_maximum import mini2  # noqa: F401
+from ..plans.peak_position import cen  # noqa: F401
+from ..plans.peak_position import com  # noqa: F401
+from ..plans.peak_position import maxi  # noqa: F401
+from ..plans.peak_position import mini  # noqa: F401
+from ..plans.peak_position import peak  # noqa: F401
+from ..plans.peak_position import peak_pos  # noqa: F401
+from ..plans.peak_position import pmax  # noqa: F401
+from ..plans.peak_position import pmin  # noqa: F401
+
+# Session-level singletons.
+from ..utils.attenuator_utils import atten  # noqa: F401
+from ..utils.counters_class import counters  # noqa: F401
+from ..utils.run_engine import peaks  # noqa: F401
+
+__all__ = [
+    # devices
+    "oregistry",
+    # scan plans
+    "ascan",
+    "count",
+    "lup",
+    "qxscan",
+    "mv",
+    "mvr",
+    "grid_scan",
+    "rel_grid_scan",
+    "hklscan",
+    "hscan",
+    "kscan",
+    "lscan",
+    "psiscan",
+    "th2th",
+    # peak finding (new + legacy)
+    "cen",
+    "com",
+    "maxi",
+    "mini",
+    "peak",
+    "peak_pos",
+    "pmax",
+    "pmin",
+    "cen2",
+    "maxi2",
+    "mini2",
+    # session singletons
+    "atten",
+    "counters",
+    "peaks",
+]

--- a/src/id4_common/macros/macros_api.py
+++ b/src/id4_common/macros/macros_api.py
@@ -41,6 +41,12 @@ from ..plans.base_scans import ascan  # noqa: F401
 from ..plans.base_scans import count  # noqa: F401
 from ..plans.base_scans import lup  # noqa: F401
 from ..plans.base_scans import qxscan  # noqa: F401
+
+# Peak-finding plans (the new findpeaks-style cen/com/maxi/mini from #59
+# plus the BEC-driven cen2/maxi2/mini2 fallbacks).
+from ..plans.center_maximum import cen2  # noqa: F401
+from ..plans.center_maximum import maxi2  # noqa: F401
+from ..plans.center_maximum import mini2  # noqa: F401
 from ..plans.grid_scans import grid_scan  # noqa: F401
 from ..plans.grid_scans import rel_grid_scan  # noqa: F401
 from ..plans.hkl_scans import hklscan  # noqa: F401
@@ -51,12 +57,6 @@ from ..plans.hkl_scans import psiscan  # noqa: F401
 from ..plans.hkl_scans import th2th  # noqa: F401
 from ..plans.move_plans import mv  # noqa: F401
 from ..plans.move_plans import mvr  # noqa: F401
-
-# Peak-finding plans (the new findpeaks-style cen/com/maxi/mini from #59
-# plus the BEC-driven cen2/maxi2/mini2 fallbacks).
-from ..plans.center_maximum import cen2  # noqa: F401
-from ..plans.center_maximum import maxi2  # noqa: F401
-from ..plans.center_maximum import mini2  # noqa: F401
 from ..plans.peak_position import cen  # noqa: F401
 from ..plans.peak_position import com  # noqa: F401
 from ..plans.peak_position import maxi  # noqa: F401

--- a/src/id4_common/macros/shortcuts_4idg_euler.py
+++ b/src/id4_common/macros/shortcuts_4idg_euler.py
@@ -1,0 +1,27 @@
+from apsbits.core.instrument_init import oregistry  # noqa: F401
+from logging import getLogger
+import sys
+
+logger = getLogger(__name__)
+_diff = oregistry.find("huber_hp")
+MAIN_NAMESPACE = "__main__"
+namespace = sys.modules[MAIN_NAMESPACE]
+
+logger.info("Adding devices shortcuts to the main namespace:")
+for item in (
+    'h',
+    'k',
+    'l',
+    'tau',
+    'mu',
+    'gamma',
+    'delta',
+    'chi',
+    'phi',
+    'x',
+    'y',
+    'z'
+):
+    dev = getattr(_diff, item)
+    logger.info(f"{dev.name} --> {item}")
+    setattr(namespace, item, dev)

--- a/src/id4_common/macros/shortcuts_4idg_euler.py
+++ b/src/id4_common/macros/shortcuts_4idg_euler.py
@@ -1,6 +1,16 @@
-from apsbits.core.instrument_init import oregistry  # noqa: F401
-from logging import getLogger
+"""Bind 4-ID-G Euler diffractometer motor shortcuts into the interactive session.
+
+Resolves the diffractometer from ``oregistry`` at import time and
+assigns each named sub-device to ``__main__`` under the same short
+name. Importing this module is the side-effect: ``import
+id4_common.macros.shortcuts_4idg_euler`` makes ``h``, ``k``, ``l``,
+``gamma``, ``delta``, ... directly usable in the IPython session.
+"""
+
 import sys
+from logging import getLogger
+
+from apsbits.core.instrument_init import oregistry
 
 logger = getLogger(__name__)
 _diff = oregistry.find("huber_hp")
@@ -9,18 +19,18 @@ namespace = sys.modules[MAIN_NAMESPACE]
 
 logger.info("Adding devices shortcuts to the main namespace:")
 for item in (
-    'h',
-    'k',
-    'l',
-    'tau',
-    'mu',
-    'gamma',
-    'delta',
-    'chi',
-    'phi',
-    'x',
-    'y',
-    'z'
+    "h",
+    "k",
+    "l",
+    "tau",
+    "mu",
+    "gamma",
+    "delta",
+    "chi",
+    "phi",
+    "x",
+    "y",
+    "z",
 ):
     dev = getattr(_diff, item)
     logger.info(f"{dev.name} --> {item}")

--- a/src/id4_common/macros/shortcuts_4idg_hp.py
+++ b/src/id4_common/macros/shortcuts_4idg_hp.py
@@ -1,0 +1,37 @@
+from apsbits.core.instrument_init import oregistry  # noqa: F401
+from logging import getLogger
+import sys
+
+logger = getLogger(__name__)
+_diff = oregistry.find("huber_hp")
+MAIN_NAMESPACE = "__main__"
+namespace = sys.modules[MAIN_NAMESPACE]
+
+logger.info("Adding devices shortcuts to the main namespace:")
+for item in (
+    'h',
+    'k',
+    'l',
+    'tau',
+    'mu',
+    'gamma',
+    'delta',
+    'chi',
+    'phi',
+    'basex',
+    'basey',
+    'basez',
+    'basey_motor',
+    'basez_motor',
+    'sample_tilt',
+    'x',
+    'y',
+    'z',
+    'nanox',
+    'nanoy',
+    'nanoz',
+    'xeryon'
+):
+    dev = getattr(_diff, item)
+    logger.info(f"{dev.name} --> {item}")
+    setattr(namespace, item, dev)

--- a/src/id4_common/macros/shortcuts_4idg_hp.py
+++ b/src/id4_common/macros/shortcuts_4idg_hp.py
@@ -1,6 +1,17 @@
-from apsbits.core.instrument_init import oregistry  # noqa: F401
-from logging import getLogger
+"""Bind 4-ID-G HP diffractometer motor shortcuts into the interactive session.
+
+Resolves ``huber_hp`` from ``oregistry`` at import time and assigns
+each named sub-device to ``__main__`` under the same short name.
+Importing this module is the side-effect: ``import
+id4_common.macros.shortcuts_4idg_hp`` makes ``h``, ``k``, ``l``,
+``nanox``, ``sample_tilt``, ``xeryon``, ... directly usable in the
+IPython session.
+"""
+
 import sys
+from logging import getLogger
+
+from apsbits.core.instrument_init import oregistry
 
 logger = getLogger(__name__)
 _diff = oregistry.find("huber_hp")
@@ -9,28 +20,28 @@ namespace = sys.modules[MAIN_NAMESPACE]
 
 logger.info("Adding devices shortcuts to the main namespace:")
 for item in (
-    'h',
-    'k',
-    'l',
-    'tau',
-    'mu',
-    'gamma',
-    'delta',
-    'chi',
-    'phi',
-    'basex',
-    'basey',
-    'basez',
-    'basey_motor',
-    'basez_motor',
-    'sample_tilt',
-    'x',
-    'y',
-    'z',
-    'nanox',
-    'nanoy',
-    'nanoz',
-    'xeryon'
+    "h",
+    "k",
+    "l",
+    "tau",
+    "mu",
+    "gamma",
+    "delta",
+    "chi",
+    "phi",
+    "basex",
+    "basey",
+    "basez",
+    "basey_motor",
+    "basez_motor",
+    "sample_tilt",
+    "x",
+    "y",
+    "z",
+    "nanox",
+    "nanoy",
+    "nanoz",
+    "xeryon",
 ):
     dev = getattr(_diff, item)
     logger.info(f"{dev.name} --> {item}")

--- a/src/id4_common/macros/shortcuts_4idh_9T.py
+++ b/src/id4_common/macros/shortcuts_4idh_9T.py
@@ -1,6 +1,17 @@
-from apsbits.core.instrument_init import oregistry  # noqa: F401
-from logging import getLogger
+"""Bind 4-ID-H 9-Tesla magnet motor shortcuts into the interactive session.
+
+Resolves ``magnet911`` from ``oregistry`` at import time, walks each
+``device.subattr`` dotted path, and assigns the resulting object to
+``__main__`` under the requested short name. Importing this module is
+the side-effect: ``import id4_common.macros.shortcuts_4idh_9T`` makes
+``field``, ``tabx``, ``sy``, ... directly usable in the IPython
+session.
+"""
+
 import sys
+from logging import getLogger
+
+from apsbits.core.instrument_init import oregistry
 
 logger = getLogger(__name__)
 _mag = oregistry.find("magnet911")
@@ -8,7 +19,7 @@ MAIN_NAMESPACE = "__main__"
 namespace = sys.modules[MAIN_NAMESPACE]
 
 logger.info("Adding devices shortcuts to the main namespace:")
-for item, label in {
+for path, label in {
     "ps.field": "field",
     "tab.x": "tabx",
     "tab.y": "taby",
@@ -18,7 +29,9 @@ for item, label in {
     "tab.srot": "tabrot",
     "samp.y": "sy",
     "samp.th": "sth",
-}:
-    dev = getattr(_mag, item)
-    logger.info(f"{dev.name} --> {item}")
-    setattr(namespace, item, dev)
+}.items():
+    dev = _mag
+    for part in path.split("."):
+        dev = getattr(dev, part)
+    logger.info(f"{dev.name} --> {label}")
+    setattr(namespace, label, dev)

--- a/src/id4_common/macros/shortcuts_4idh_9T.py
+++ b/src/id4_common/macros/shortcuts_4idh_9T.py
@@ -1,0 +1,24 @@
+from apsbits.core.instrument_init import oregistry  # noqa: F401
+from logging import getLogger
+import sys
+
+logger = getLogger(__name__)
+_mag = oregistry.find("magnet911")
+MAIN_NAMESPACE = "__main__"
+namespace = sys.modules[MAIN_NAMESPACE]
+
+logger.info("Adding devices shortcuts to the main namespace:")
+for item, label in {
+    "ps.field": "field",
+    "tab.x": "tabx",
+    "tab.y": "taby",
+    "tab.z": "tabz",
+    "tab.sx": "tabsx",
+    "tab.sz": "tabsz",
+    "tab.srot": "tabrot",
+    "samp.y": "sy",
+    "samp.th": "sth",
+}:
+    dev = getattr(_mag, item)
+    logger.info(f"{dev.name} --> {item}")
+    setattr(namespace, item, dev)

--- a/src/id4_common/macros/startup_common.py
+++ b/src/id4_common/macros/startup_common.py
@@ -1,5 +1,16 @@
-from id4_common.utils.session_state import restore_session_state
+"""One-line session-restart helper.
+
+Importing this module runs the canonical post-restart sequence:
+``experiment_resume()`` (auto-discovers the experiment snapshot from
+the cwd or the most recent run in the catalog) followed by
+``restore_session_state()`` (re-applies every auto-saved setup knob —
+PR setup, energy tracking, undulator offsets, counters, qxscan
+params). The per-knob status dict is printed so the user can see what
+was applied / skipped / failed.
+"""
+
 from id4_common.utils.experiment_utils import experiment_resume
+from id4_common.utils.session_state import restore_session_state
 
 experiment_resume()
 status = restore_session_state()

--- a/src/id4_common/macros/startup_common.py
+++ b/src/id4_common/macros/startup_common.py
@@ -1,0 +1,7 @@
+from id4_common.utils.session_state import restore_session_state
+from id4_common.utils.experiment_utils import experiment_resume
+
+experiment_resume()
+status = restore_session_state()
+for knob, msg in status.items():
+    print(f"  {knob:18}  {msg}")

--- a/src/id4_common/utils/counters_class.py
+++ b/src/id4_common/utils/counters_class.py
@@ -544,6 +544,16 @@ class CountersClass:
         )
         self._apply_extra_read(stored_extra, options)
 
+        # Auto-save the new selection to RE.md['session_state'] so it
+        # survives a bluesky restart.  Lazy import avoids the
+        # session_state -> counters_class -> session_state cycle.
+        try:
+            from .session_state import _save_counters
+
+            _save_counters()
+        except Exception:  # noqa: BLE001
+            pass
+
         print()
         print(self)
 

--- a/src/id4_common/utils/pr_setup.py
+++ b/src/id4_common/utils/pr_setup.py
@@ -7,11 +7,56 @@ from apsbits.core.instrument_init import oregistry
 from ..callbacks.dichro_stream import plot_dichro_settings
 
 
+def _autosave():
+    """Mirror current pr_setup state into RE.md['session_state'].
+
+    Imported lazily to avoid a module-load cycle (session_state imports
+    from pr_setup too).  Runs after every property-setter write so direct
+    attribute assignments — the pattern user startup files use today —
+    persist automatically.
+    """
+    try:
+        from .session_state import _save_pr_setup
+    except Exception:  # noqa: BLE001 — never break a property setter
+        return
+    _save_pr_setup()
+
+
 class PRSetup:
-    positioner = None
-    offset = None
-    oscillate_pzt = True
     _dichro_steps = [1, -1, -1, 1]
+
+    def __init__(self):
+        self._current_setup = {}
+        self._positioner = None
+        self._offset = None
+        self._oscillate_pzt = True
+
+    @property
+    def positioner(self):
+        return self._positioner
+
+    @positioner.setter
+    def positioner(self, value):
+        self._positioner = value
+        _autosave()
+
+    @property
+    def offset(self):
+        return self._offset
+
+    @offset.setter
+    def offset(self, value):
+        self._offset = value
+        _autosave()
+
+    @property
+    def oscillate_pzt(self):
+        return self._oscillate_pzt
+
+    @oscillate_pzt.setter
+    def oscillate_pzt(self, value):
+        self._oscillate_pzt = bool(value)
+        _autosave()
 
     @property
     def dichro_steps(self):
@@ -29,9 +74,6 @@ class PRSetup:
             raise ValueError("No phase retarder was found!")
         prs.sort(key=lambda x: x.name)
         return prs
-
-    def __init__(self):
-        self._current_setup = {}
 
     def __repr__(self):
         tracked = ""

--- a/src/id4_common/utils/session_state.py
+++ b/src/id4_common/utils/session_state.py
@@ -1,0 +1,346 @@
+"""
+Auto-saved per-experiment session state in ``RE.md['session_state']``.
+
+Each setup helper in this package — ``pr_setup``, ``energy.tracking_setup``,
+``counters.plotselect``, ``undulator_setup``, ``qxscan_setup`` — calls the
+matching ``_save_*`` helper at the tail of its body.  The snapshot is
+mirrored into the apsbits ``RE.md`` ``PersistentDict`` so it survives
+bluesky restarts.
+
+To re-apply every saved knob after a restart::
+
+    from id4_common.utils.session_state import restore_session_state
+    status = restore_session_state()
+    for knob, s in status.items():
+        print(f"  {knob:18}  {s}")
+
+Each restore step reports ``"applied"`` / ``"skipped: <reason>"`` /
+``"failed: <Exception>"``.  ``restore_session_state`` never raises — a
+missing device or a single failed put is logged and the rest of the
+restore continues.
+
+The schema under ``RE.md['session_state']`` is a nested dict with one
+sub-key per knob group:
+
+- ``saved_at``         (str, ISO timestamp; refreshed on every save)
+- ``undulators``       (``{us|ds: {energy_offset, energy_deadband}}``)
+- ``energy_tracking``  (``{devices: [name, ...]}``)
+- ``pr_setup``         (``{positioner, offset, oscillate_pzt}``)
+- ``counters``         (``{detectors, monitor, extra_read}`` — by
+  ``(device, channel)`` pairs to survive index shifts)
+- ``qxscan``           (``{source}`` (json filename) or ``{params}``)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from apsbits.core.instrument_init import oregistry
+
+from .run_engine import RE
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "restore_session_state",
+    "save_session_state",
+]
+
+_TOP_KEY = "session_state"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot read / commit primitives
+# ---------------------------------------------------------------------------
+
+
+def _state() -> dict:
+    """Return the current session_state dict (empty if absent or RE.md is
+    not yet ready).
+    """
+    try:
+        existing = RE.md.get(_TOP_KEY)
+    except Exception:  # noqa: BLE001 — RE may be absent very early at startup
+        return {}
+    if not isinstance(existing, dict):
+        return {}
+    return dict(existing)
+
+
+def _commit(state: dict) -> None:
+    """Write the snapshot back, refreshing ``saved_at``."""
+    state["saved_at"] = datetime.now().isoformat(timespec="seconds")
+    try:
+        RE.md[_TOP_KEY] = state
+    except Exception as exc:  # noqa: BLE001 — never break a setup function
+        logger.warning("Could not persist session_state to RE.md: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Per-knob save helpers — called from each setup function's tail
+# ---------------------------------------------------------------------------
+
+
+def _save_undulator() -> None:
+    """Snapshot ``energy_offset`` and ``energy_deadband`` for both undulators."""
+    undulators = oregistry.find("undulators", allow_none=True)
+    if undulators is None:
+        return
+    snapshot: dict = {}
+    for side in ("us", "ds"):
+        dev = getattr(undulators, side, None)
+        if dev is None:
+            continue
+        try:
+            snapshot[side] = {
+                "energy_offset": float(dev.energy_offset.get()),
+                "energy_deadband": float(dev.energy_deadband.get()),
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.info(
+                "session_state: could not read %s undulator offset: %s",
+                side,
+                exc,
+            )
+    if not snapshot:
+        return
+    state = _state()
+    state["undulators"] = snapshot
+    _commit(state)
+
+
+def _save_energy_tracking() -> None:
+    """Snapshot the names of every device currently flagged as tracking."""
+    energy = oregistry.find("energy", allow_none=True)
+    if energy is None:
+        return
+    try:
+        active = [
+            d.name for d in energy.trackable_devices if d.tracking.get()
+        ]
+    except Exception as exc:  # noqa: BLE001
+        logger.info(
+            "session_state: could not read energy tracking state: %s", exc
+        )
+        return
+    state = _state()
+    state["energy_tracking"] = {"devices": active}
+    _commit(state)
+
+
+def _save_pr_setup() -> None:
+    """Snapshot the active ``pr_setup`` positioner / offset / oscillate flag."""
+    try:
+        from .pr_setup import pr_setup as _pr
+    except Exception as exc:  # noqa: BLE001
+        logger.info("session_state: pr_setup not importable: %s", exc)
+        return
+    snapshot = {
+        "positioner": getattr(_pr.positioner, "name", None),
+        "offset": getattr(_pr.offset, "name", None),
+        "oscillate_pzt": bool(_pr.oscillate_pzt),
+    }
+    state = _state()
+    state["pr_setup"] = snapshot
+    _commit(state)
+
+
+def _save_counters() -> None:
+    """Snapshot ``counters.plotselect`` dets/mon/extra_read by (dev, channel)."""
+    try:
+        from .counters_class import counters as _c
+    except Exception as exc:  # noqa: BLE001
+        logger.info("session_state: counters not importable: %s", exc)
+        return
+    snapshot = {
+        "detectors": [list(t) for t in _c._selected_dets],
+        "monitor": list(_c._selected_mon) if _c._selected_mon else None,
+        "extra_read": [list(t) for t in _c._selected_extra_read],
+    }
+    state = _state()
+    state["counters"] = snapshot
+    _commit(state)
+
+
+def _save_qxscan(*, source: str | None = None) -> None:
+    """Snapshot the qxscan setup — by file pointer when available, else inline."""
+    qx = oregistry.find("qxscan_setup", allow_none=True)
+    if qx is None:
+        return
+    snapshot: dict = {}
+    if source is not None:
+        snapshot["source"] = str(source)
+    else:
+        try:
+            snapshot["params"] = qx._make_params_dict()
+        except Exception as exc:  # noqa: BLE001
+            logger.info("session_state: could not read qxscan params: %s", exc)
+            return
+    state = _state()
+    state["qxscan"] = snapshot
+    _commit(state)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def save_session_state() -> dict:
+    """Snapshot every supported knob (escape hatch — normal flow is the
+    auto-save hooks).
+    """
+    _save_undulator()
+    _save_energy_tracking()
+    _save_pr_setup()
+    _save_counters()
+    _save_qxscan()
+    return _state()
+
+
+def restore_session_state(state: dict | None = None) -> dict:
+    """Re-apply every knob from ``RE.md['session_state']`` (or ``state``).
+
+    Returns ``{knob_group: status_str}`` so callers can print a summary.
+    Never raises.
+    """
+    if state is None:
+        state = _state()
+    status: dict = {}
+    if not state:
+        status["session_state"] = "skipped: no snapshot in RE.md"
+        return status
+
+    if "undulators" in state:
+        status["undulators"] = _restore_undulator(state["undulators"])
+    if "energy_tracking" in state:
+        status["energy_tracking"] = _restore_energy_tracking(
+            state["energy_tracking"]
+        )
+    if "pr_setup" in state:
+        status["pr_setup"] = _restore_pr_setup(state["pr_setup"])
+    if "counters" in state:
+        status["counters"] = _restore_counters(state["counters"])
+    if "qxscan" in state:
+        status["qxscan"] = _restore_qxscan(state["qxscan"])
+
+    return status
+
+
+# ---------------------------------------------------------------------------
+# Per-knob restore helpers — never raise
+# ---------------------------------------------------------------------------
+
+
+def _restore_undulator(snapshot: dict) -> str:
+    undulators = oregistry.find("undulators", allow_none=True)
+    if undulators is None:
+        return "skipped: undulators not loaded"
+    try:
+        for side, knobs in snapshot.items():
+            dev = getattr(undulators, side, None)
+            if dev is None:
+                continue
+            if "energy_offset" in knobs:
+                dev.energy_offset.put(float(knobs["energy_offset"]))
+            if "energy_deadband" in knobs:
+                dev.energy_deadband.put(float(knobs["energy_deadband"]))
+        return "applied"
+    except Exception as exc:  # noqa: BLE001
+        return f"failed: {type(exc).__name__}: {exc}"
+
+
+def _restore_energy_tracking(snapshot: dict) -> str:
+    energy = oregistry.find("energy", allow_none=True)
+    if energy is None:
+        return "skipped: energy not loaded"
+    try:
+        energy.tracking_setup(snapshot.get("devices", []))
+        return "applied"
+    except Exception as exc:  # noqa: BLE001
+        return f"failed: {type(exc).__name__}: {exc}"
+
+
+def _restore_pr_setup(snapshot: dict) -> str:
+    try:
+        from .pr_setup import pr_setup as _pr
+    except Exception as exc:  # noqa: BLE001
+        return f"failed: {type(exc).__name__}: {exc}"
+    try:
+        positioner_name = snapshot.get("positioner")
+        offset_name = snapshot.get("offset")
+        positioner = (
+            oregistry.find(positioner_name, allow_none=True)
+            if positioner_name
+            else None
+        )
+        offset = (
+            oregistry.find(offset_name, allow_none=True)
+            if offset_name
+            else None
+        )
+        if positioner_name and positioner is None:
+            return f"skipped: positioner {positioner_name!r} not loaded"
+        if offset_name and offset is None:
+            return f"skipped: offset {offset_name!r} not loaded"
+        _pr.positioner = positioner
+        _pr.offset = offset
+        _pr.oscillate_pzt = bool(snapshot.get("oscillate_pzt", True))
+        return "applied"
+    except Exception as exc:  # noqa: BLE001
+        return f"failed: {type(exc).__name__}: {exc}"
+
+
+def _restore_counters(snapshot: dict) -> str:
+    try:
+        from .counters_class import counters as _c
+    except Exception as exc:  # noqa: BLE001
+        return f"failed: {type(exc).__name__}: {exc}"
+    try:
+        options = _c.detectors_plot_options
+
+        def _index(pair):
+            if not pair:
+                return None
+            dev, chan = pair
+            mask = (options["detectors"] == dev) & (
+                options["channels"] == chan
+            )
+            if not mask.any():
+                return None
+            return int(options.index[mask][0])
+
+        det_idx = [
+            i
+            for i in (_index(p) for p in snapshot.get("detectors", []))
+            if i is not None
+        ]
+        mon_idx = _index(snapshot.get("monitor"))
+        extra_idx = [
+            i
+            for i in (_index(p) for p in snapshot.get("extra_read", []))
+            if i is not None
+        ]
+        if not det_idx or mon_idx is None:
+            return "skipped: saved channels not in current options"
+        _c.plotselect(dets=det_idx, mon=mon_idx, extra_read=extra_idx)
+        return "applied"
+    except Exception as exc:  # noqa: BLE001
+        return f"failed: {type(exc).__name__}: {exc}"
+
+
+def _restore_qxscan(snapshot: dict) -> str:
+    qx = oregistry.find("qxscan_setup", allow_none=True)
+    if qx is None:
+        return "skipped: qxscan_setup not loaded"
+    try:
+        if "source" in snapshot:
+            qx.load_params_json(snapshot["source"])
+            return f"applied (from {snapshot['source']})"
+        if "params" in snapshot:
+            qx._read_params_dict(snapshot["params"])
+            return "applied (from inline params)"
+        return "skipped: no qxscan source/params in snapshot"
+    except Exception as exc:  # noqa: BLE001
+        return f"failed: {type(exc).__name__}: {exc}"

--- a/src/id4_common/utils/session_state.py
+++ b/src/id4_common/utils/session_state.py
@@ -116,9 +116,7 @@ def _save_energy_tracking() -> None:
     if energy is None:
         return
     try:
-        active = [
-            d.name for d in energy.trackable_devices if d.tracking.get()
-        ]
+        active = [d.name for d in energy.trackable_devices if d.tracking.get()]
     except Exception as exc:  # noqa: BLE001
         logger.info(
             "session_state: could not read energy tracking state: %s", exc
@@ -304,9 +302,7 @@ def _restore_counters(snapshot: dict) -> str:
             if not pair:
                 return None
             dev, chan = pair
-            mask = (options["detectors"] == dev) & (
-                options["channels"] == chan
-            )
+            mask = (options["detectors"] == dev) & (options["channels"] == chan)
             if not mask.any():
                 return None
             return int(options.index[mask][0])

--- a/src/id4_common/utils/undulator_setup.py
+++ b/src/id4_common/utils/undulator_setup.py
@@ -1,25 +1,117 @@
-"""Utility for configuring upstream and downstream undulator setpoints."""
+"""Utility for configuring upstream and downstream undulator setpoints.
+
+The single public function, :func:`undulator_setup`, walks the user
+through an interactive prompt for each undulator (DS = downstream, US =
+upstream): whether to track the mono energy, what offset (in keV) to
+apply between mono energy and undulator setpoint, and which harmonic to
+use.  Any value passed as a kwarg short-circuits the matching prompt;
+sentinel kwarg defaults mean "ask interactively, with the current
+device state as the default answer".
+
+Sentinel values used in the kwargs (legacy API; see the module-level
+TODO at the bottom of this file for a proposed cleanup):
+
+==========  =============  ============================================
+kwarg       sentinel       meaning
+==========  =============  ============================================
+``ds``      ``"N"``        ask, defaulting to "yes" if already tracking
+``us``      ``"N"``        same
+``ds_off``  ``999``        ask, defaulting to current offset (or
+                           calculated from mono if the offset is 0)
+``us_off``  ``999``        same
+``ds_harm`` ``0``          ask, defaulting to the device's current value
+``us_harm`` ``0``          same
+==========  =============  ============================================
+
+A value of ``"c"`` for an offset (only valid when prompted) means
+"calculate from ``undulator.energy.readback - energy``"; a value of
+``"c"`` for a harmonic picks 1 / 3 / 5 from the energy thresholds in
+:data:`HARMONIC_BREAKPOINTS_KEV`.
+"""
 
 from apsbits.core.instrument_init import oregistry
+
+# Sentinel for "kwarg not supplied"; the legacy API uses these literal
+# values instead of None.  See the cleanup TODO at the bottom of this
+# file for the proposed migration.
+_OFFSET_SENTINEL = 999  # ds_off / us_off "ask interactively" default
+_HARM_SENTINEL = 0  # ds_harm / us_harm "ask interactively" default
+
+# Energy thresholds for the "[c]alculate" harmonic auto-pick.  Below the
+# first cutoff use harmonic 1, below the second use 3, otherwise 5.
+HARMONIC_BREAKPOINTS_KEV = ((8.6, 1), (18.0, 3))
+_HARMONIC_FALLBACK = 5  # used when the energy is above every breakpoint
+
+
+def _auto_harmonic(energy_keV: float) -> int:
+    """Pick an undulator harmonic from the mono energy."""
+    for cutoff, harm in HARMONIC_BREAKPOINTS_KEV:
+        if energy_keV < cutoff:
+            return harm
+    return _HARMONIC_FALLBACK
 
 
 def undulator_setup(
     ds="N", ds_off=999, ds_harm=0, us="N", us_off=999, us_harm=0
 ):
     """
-    Select undulators used and turn energy tracking on/off
+    Configure each undulator's tracking, offset, and harmonic.
 
-    - Undulator offset denotes difference of undulator energy to
-      monochromator energy
-      - [c]alculate: calculates offset from monochromator and
-        undulator current energies
+    Walks DS then US, asking three questions per undulator:
+    "Use it?" → "Offset?" → "Harmonic?".  Any kwarg whose value differs
+    from its sentinel skips the matching prompt.
 
+    Parameters
+    ----------
+    ds, us : {"Y", "y", "yes", "Yes", "N", "n", "no", "No"}, optional
+        Whether the undulator should track the mono energy.  ``"N"`` is
+        the sentinel that triggers an interactive prompt (default).
+        Default answer at the prompt: "yes" if the device is currently
+        tracking, else "no".
+    ds_off, us_off : float, optional
+        Offset in keV applied between the mono energy and the undulator
+        setpoint.  Sentinel ``999`` triggers an interactive prompt that
+        also accepts the literal string ``"c"`` to calculate the offset
+        from ``undulator.energy.readback - energy``.  When the
+        device's current ``energy_offset`` is 0 the prompt's default
+        is the calculated value (assumed-uninitialised); otherwise the
+        prompt's default is the current offset.
+    ds_harm, us_harm : int, optional
+        Undulator harmonic.  Must be an odd integer in {1, 3, 5, 7, 9}.
+        Sentinel ``0`` triggers an interactive prompt that also accepts
+        the literal string ``"c"`` to auto-pick from the mono energy
+        via :data:`HARMONIC_BREAKPOINTS_KEV`.
 
+    Side effects
+    ------------
+    Writes ``undulators.{ds,us}.energy_offset``,
+    ``…tracking``, and ``…harmonic_value`` for whichever undulators
+    are turned on.  Prints a one-line summary per undulator.
+
+    The auto-save hook at the end of the function mirrors the new
+    offsets / deadbands into ``RE.md["session_state"]`` so a bluesky
+    restart can re-apply them via
+    :func:`id4_common.utils.session_state.restore_session_state`.
+
+    See Also
+    --------
+    :func:`id4_common.devices.energy_device.EnergySignal.tracking_setup`
+        Higher-level "which devices follow energy" selector — typically
+        called *with* this function (after this sets per-undulator
+        offsets/harmonics, ``tracking_setup`` flips the tracking flags
+        in one go).
+    :func:`id4_common.utils.session_state.restore_session_state`
+        Replays the saved offsets / harmonics / tracking flags after a
+        bluesky restart.
     """
 
     undulators = oregistry.find("undulators")
     energy = oregistry.find("energy")
 
+    # The flag dance below answers, for each kwarg, "did the caller
+    # supply a value, or should we prompt?"  When a sentinel matches we
+    # also seed the prompt's default with a sensible value pulled from
+    # the live device state.
     ds_inq = False
     us_inq = False
     ds_off_inq = False
@@ -27,6 +119,8 @@ def undulator_setup(
     if ds != "N":
         ds_inq = True
     elif ds == "N" and undulators.ds.tracking.get():
+        # No kwarg given but the device is already tracking → default the
+        # prompt to "yes" so the user just hits enter to keep tracking.
         ds = "Y"
         ds_inq = False
     else:
@@ -40,31 +134,41 @@ def undulator_setup(
     else:
         us_inq = False
 
-    if undulators.ds.energy_offset.get() == 0 and ds_off == 999:
+    # Offset defaults: if the device's current offset is 0 (probably
+    # uninitialised) and the caller didn't pass a value, default the
+    # prompt to the *calculated* offset (mono - undulator readback).
+    # Otherwise default to the device's current offset.  When the
+    # caller supplies a value via kwarg, skip the prompt entirely.
+    if undulators.ds.energy_offset.get() == 0 and ds_off == _OFFSET_SENTINEL:
         ds_off = undulators.ds.energy.readback.get() - energy.get()
-    elif ds_off == 999:
+    elif ds_off == _OFFSET_SENTINEL:
         ds_off = undulators.ds.energy_offset.get()
     else:
         ds_off_inq = True
-    if undulators.us.energy_offset.get() == 0 and us_off == 999:
+    if undulators.us.energy_offset.get() == 0 and us_off == _OFFSET_SENTINEL:
         us_off = undulators.us.energy.readback.get() - energy.get()
-    elif us_off == 999:
+    elif us_off == _OFFSET_SENTINEL:
         us_off = undulators.us.energy_offset.get()
     else:
         us_off_inq = True
 
-    if ds_harm == 0:
+    # Harmonic defaults: pull from the device unless a kwarg was passed.
+    if ds_harm == _HARM_SENTINEL:
         ds_harm = undulators.ds.harmonic_value.get()
         ds_harm_inq = False
     else:
         ds_harm_inq = True
 
-    if us_harm == 0:
+    if us_harm == _HARM_SENTINEL:
         us_harm = undulators.us.harmonic_value.get()
         us_harm_inq = False
     else:
         us_harm_inq = True
 
+    # ----------------------------------------------------------------
+    # DS undulator  (the US branch below is byte-identical except for
+    # the side prefix — see the cleanup TODO at the end of the file).
+    # ----------------------------------------------------------------
     ds = ds if ds_inq else input(f"Use DS undulator [{ds}]: ") or ds
     if ds in ["Yes", "Y", "y", "yes"]:
         ds_off = (
@@ -86,13 +190,7 @@ def undulator_setup(
             or ds_harm
         )
         if ds_harm == "c":
-            en = energy.get()
-            if en < 8.6:
-                ds_harm = 1
-            elif en < 18:
-                ds_harm = 3
-            else:
-                ds_harm = 5
+            ds_harm = _auto_harmonic(energy.get())
 
         undulators.ds.energy_offset.put(float(ds_off))
         undulators.ds.tracking.put(True)
@@ -109,6 +207,9 @@ def undulator_setup(
         undulators.ds.tracking.put(False)
         print("DS undulator tracking OFF\n")
 
+    # ----------------------------------------------------------------
+    # US undulator  (duplicate of DS branch above — see cleanup TODO).
+    # ----------------------------------------------------------------
     us = us if us_inq else input(f"Use US undulator [{us}]: ") or us
     if us in ["Yes", "Y", "y", "yes"]:
         us_off = (
@@ -129,14 +230,11 @@ def undulator_setup(
             )
             or us_harm
         )
+        # NOTE: previously this branch wrote to ``ds_harm`` instead of
+        # ``us_harm`` — a copy-paste bug from the duplicated DS/US logic.
+        # Fixed here to write to the correct US variable.
         if us_harm == "c":
-            en = energy.get()
-            if en < 8.6:
-                ds_harm = 1
-            elif en < 18:
-                ds_harm = 3
-            else:
-                ds_harm = 5
+            us_harm = _auto_harmonic(energy.get())
         undulators.us.energy_offset.put(float(us_off))
         undulators.us.tracking.put(True)
         try:
@@ -161,3 +259,38 @@ def undulator_setup(
         _save_undulator()
     except Exception:  # noqa: BLE001
         pass
+
+
+# ---------------------------------------------------------------------------
+# TODO(undulator_setup cleanup) — see the chat thread that introduced this
+# block.  Keeping the function as-is for now to avoid behaviour change in
+# the same PR as session_state; revisit as a focused refactor.
+#
+# Concrete items:
+#
+# 1. Replace the magic sentinels (999 / 0 / "N") with ``None`` so the
+#    "kwarg supplied vs not" check is just ``if value is None:``.  Drops
+#    the six ``*_inq`` flags entirely.
+#
+# 2. Extract the per-side block (lines under "DS undulator" / "US
+#    undulator" banners) into a private ``_setup_one_side(side, …)``
+#    helper called twice.  Halves the function length and removes the
+#    class of bugs that produced the harmonic copy-paste mistake just
+#    fixed in this commit.
+#
+# 3. Catch a specific exception in the harmonic ``try`` blocks instead of
+#    bare ``Exception``.  Today's ``except Exception:`` swallows real
+#    bugs along with "undulator disabled" timeouts.
+#
+# 4. Decide whether ``undulator_setup`` should still toggle each
+#    undulator's ``.tracking`` flag at all, given that
+#    ``energy.tracking_setup([...])`` is the canonical "which devices
+#    follow energy" selector.  Two paths to the same state are confusing.
+#    Likely outcome: keep the offset/harmonic prompts here, drop the
+#    on/off prompt and document that users go through
+#    ``energy.tracking_setup`` for that toggle.
+#
+# 5. Once 1–4 are done the function shrinks to ~50 lines with one
+#    docstring per public symbol; the current block-comment scaffolding
+#    (the "DS undulator" / "US undulator" banners) becomes redundant.
+# ---------------------------------------------------------------------------

--- a/src/id4_common/utils/undulator_setup.py
+++ b/src/id4_common/utils/undulator_setup.py
@@ -1,46 +1,38 @@
-"""Utility for configuring upstream and downstream undulator setpoints.
+"""Utility for configuring upstream and downstream undulator offsets.
 
 The single public function, :func:`undulator_setup`, walks the user
 through an interactive prompt for each undulator (DS = downstream, US =
-upstream): whether to track the mono energy, what offset (in keV) to
-apply between mono energy and undulator setpoint, and which harmonic to
-use.  Any value passed as a kwarg short-circuits the matching prompt;
-sentinel kwarg defaults mean "ask interactively, with the current
-device state as the default answer".
+upstream): what offset (in keV) to apply between mono energy and
+undulator setpoint, and which harmonic to use.  Any value passed as a
+kwarg short-circuits the matching prompt; ``None`` (the default) means
+"ask interactively, with the current device state as the default
+answer".
 
-Sentinel values used in the kwargs (legacy API; see the module-level
-TODO at the bottom of this file for a proposed cleanup):
+What this function does **not** do
+----------------------------------
 
-==========  =============  ============================================
-kwarg       sentinel       meaning
-==========  =============  ============================================
-``ds``      ``"N"``        ask, defaulting to "yes" if already tracking
-``us``      ``"N"``        same
-``ds_off``  ``999``        ask, defaulting to current offset (or
-                           calculated from mono if the offset is 0)
-``us_off``  ``999``        same
-``ds_harm`` ``0``          ask, defaulting to the device's current value
-``us_harm`` ``0``          same
-==========  =============  ============================================
+It does not toggle each undulator's ``.tracking`` flag.  Use
+:func:`id4_common.devices.energy_device.EnergySignal.tracking_setup` for
+that — it's the single source of truth for "which devices follow the
+mono energy".
 
-A value of ``"c"`` for an offset (only valid when prompted) means
-"calculate from ``undulator.energy.readback - energy``"; a value of
-``"c"`` for a harmonic picks 1 / 3 / 5 from the energy thresholds in
-:data:`HARMONIC_BREAKPOINTS_KEV`.
+Typical workflow::
+
+    undulator_setup(ds_off=-0.072, ds_harm=3)        # offset + harmonic
+    energy.tracking_setup(["undulators_ds", "pr2"])  # turn tracking on
+
+Both calls auto-save into ``RE.md["session_state"]``, so a bluesky
+restart restores both halves via
+:func:`id4_common.utils.session_state.restore_session_state`.
 """
 
 from apsbits.core.instrument_init import oregistry
-
-# Sentinel for "kwarg not supplied"; the legacy API uses these literal
-# values instead of None.  See the cleanup TODO at the bottom of this
-# file for the proposed migration.
-_OFFSET_SENTINEL = 999  # ds_off / us_off "ask interactively" default
-_HARM_SENTINEL = 0  # ds_harm / us_harm "ask interactively" default
 
 # Energy thresholds for the "[c]alculate" harmonic auto-pick.  Below the
 # first cutoff use harmonic 1, below the second use 3, otherwise 5.
 HARMONIC_BREAKPOINTS_KEV = ((8.6, 1), (18.0, 3))
 _HARMONIC_FALLBACK = 5  # used when the energy is above every breakpoint
+_VALID_HARMONICS = (1, 3, 5, 7, 9)
 
 
 def _auto_harmonic(energy_keV: float) -> int:
@@ -51,204 +43,154 @@ def _auto_harmonic(energy_keV: float) -> int:
     return _HARMONIC_FALLBACK
 
 
-def undulator_setup(
-    ds="N", ds_off=999, ds_harm=0, us="N", us_off=999, us_harm=0
-):
-    """
-    Configure each undulator's tracking, offset, and harmonic.
+def _resolve_offset(side: str, kwarg, side_dev, energy):
+    """Decide on the offset for one undulator.
 
-    Walks DS then US, asking three questions per undulator:
-    "Use it?" → "Offset?" → "Harmonic?".  Any kwarg whose value differs
-    from its sentinel skips the matching prompt.
+    - ``kwarg`` is what the caller passed (or ``None`` to prompt).
+    - The prompt's default is the device's current offset, falling back
+      to the calculated value (``undulator.energy.readback - energy``)
+      when the offset is 0 (uninitialised).
+    - Accepts the literal ``"c"`` to recompute from the live readback.
+    """
+    if kwarg is not None:
+        return float(kwarg)
+
+    current = side_dev.energy_offset.get()
+    if current == 0:
+        default = side_dev.energy.readback.get() - energy.get()
+    else:
+        default = current
+
+    while True:
+        answer = (
+            input(
+                f"   {side.upper()} undulator offset "
+                f"(value/[c]alculate) [{default:.3f}]: "
+            )
+            or default
+        )
+        if answer == "c":
+            return float(side_dev.energy.readback.get() - energy.get())
+        try:
+            return float(answer)
+        except (TypeError, ValueError):
+            print("     Offset must be a number or 'c'.")
+
+
+def _resolve_harmonic(side: str, kwarg, side_dev, energy):
+    """Decide on the harmonic for one undulator.
+
+    - ``kwarg`` is what the caller passed (or ``None`` to prompt).
+    - The prompt's default is the device's current harmonic value.
+    - Accepts the literal ``"c"`` to auto-pick from the mono energy
+      via :data:`HARMONIC_BREAKPOINTS_KEV`.
+    """
+    if kwarg is not None:
+        return int(kwarg)
+
+    default = side_dev.harmonic_value.get()
+
+    while True:
+        answer = (
+            input(
+                f"   {side.upper()} undulator harmonic "
+                f"(1,3,5,../[c]alculate) [{default:.0f}]: "
+            )
+            or default
+        )
+        if answer == "c":
+            return _auto_harmonic(energy.get())
+        try:
+            return int(answer)
+        except (TypeError, ValueError):
+            print("     Harmonic must be an odd integer or 'c'.")
+
+
+def _setup_one_side(side: str, undulators, energy, off, harm):
+    """Resolve and apply the offset + harmonic for one undulator side.
+
+    Writes ``side.energy_offset`` and (when valid) ``side.harmonic_value``.
+    Does **not** touch ``side.tracking``; tracking is configured by
+    ``energy.tracking_setup`` (see module docstring).  Prints a
+    one-line summary so interactive callers get feedback.
+    """
+    side_dev = getattr(undulators, side)
+
+    resolved_off = _resolve_offset(side, off, side_dev, energy)
+    resolved_harm = _resolve_harmonic(side, harm, side_dev, energy)
+
+    side_dev.energy_offset.put(resolved_off)
+
+    if resolved_harm in _VALID_HARMONICS:
+        try:
+            side_dev.harmonic_value.put(resolved_harm)
+            print(
+                f"{side.upper()} undulator: offset = {resolved_off:.3f}, "
+                f"harmonic = {resolved_harm}"
+            )
+        except TimeoutError:
+            # The harmonic_value PV is disconnected — typical when the
+            # undulator IOC is down.  The offset write above may also
+            # have failed silently; surface that to the user.
+            print(
+                f"     {side.upper()} harmonic_value PV unreachable — "
+                "undulator currently disabled?"
+            )
+    else:
+        print(
+            f"     {side.upper()} harmonic must be one of "
+            f"{_VALID_HARMONICS}; got {resolved_harm!r}.  Skipped."
+        )
+
+
+def undulator_setup(ds_off=None, ds_harm=None, us_off=None, us_harm=None):
+    """
+    Configure each undulator's offset and harmonic.
+
+    Walks DS then US, asking two questions per undulator: "Offset?" →
+    "Harmonic?".  Any kwarg supplied short-circuits the matching prompt.
 
     Parameters
     ----------
-    ds, us : {"Y", "y", "yes", "Yes", "N", "n", "no", "No"}, optional
-        Whether the undulator should track the mono energy.  ``"N"`` is
-        the sentinel that triggers an interactive prompt (default).
-        Default answer at the prompt: "yes" if the device is currently
-        tracking, else "no".
     ds_off, us_off : float, optional
         Offset in keV applied between the mono energy and the undulator
-        setpoint.  Sentinel ``999`` triggers an interactive prompt that
-        also accepts the literal string ``"c"`` to calculate the offset
-        from ``undulator.energy.readback - energy``.  When the
+        setpoint.  ``None`` (default) triggers an interactive prompt
+        that also accepts the literal string ``"c"`` to calculate the
+        offset from ``undulator.energy.readback - energy``.  When the
         device's current ``energy_offset`` is 0 the prompt's default
         is the calculated value (assumed-uninitialised); otherwise the
         prompt's default is the current offset.
     ds_harm, us_harm : int, optional
-        Undulator harmonic.  Must be an odd integer in {1, 3, 5, 7, 9}.
-        Sentinel ``0`` triggers an interactive prompt that also accepts
-        the literal string ``"c"`` to auto-pick from the mono energy
-        via :data:`HARMONIC_BREAKPOINTS_KEV`.
+        Undulator harmonic.  Must be an odd integer in
+        ``{1, 3, 5, 7, 9}``.  ``None`` (default) triggers an interactive
+        prompt that also accepts the literal string ``"c"`` to
+        auto-pick from the mono energy via
+        :data:`HARMONIC_BREAKPOINTS_KEV`.
 
     Side effects
     ------------
-    Writes ``undulators.{ds,us}.energy_offset``,
-    ``…tracking``, and ``…harmonic_value`` for whichever undulators
-    are turned on.  Prints a one-line summary per undulator.
+    Writes ``undulators.ds.energy_offset``, ``undulators.us.energy_offset``,
+    and the corresponding ``harmonic_value`` PVs (when reachable and
+    valid).  Auto-saves the new offsets / deadbands into
+    ``RE.md["session_state"]`` so a bluesky restart can re-apply them
+    via :func:`~id4_common.utils.session_state.restore_session_state`.
 
-    The auto-save hook at the end of the function mirrors the new
-    offsets / deadbands into ``RE.md["session_state"]`` so a bluesky
-    restart can re-apply them via
-    :func:`id4_common.utils.session_state.restore_session_state`.
+    Notes
+    -----
+    Does **not** touch ``.tracking``.  Use
+    :func:`id4_common.devices.energy_device.EnergySignal.tracking_setup`
+    to enable / disable per-device tracking.
 
     See Also
     --------
     :func:`id4_common.devices.energy_device.EnergySignal.tracking_setup`
-        Higher-level "which devices follow energy" selector — typically
-        called *with* this function (after this sets per-undulator
-        offsets/harmonics, ``tracking_setup`` flips the tracking flags
-        in one go).
     :func:`id4_common.utils.session_state.restore_session_state`
-        Replays the saved offsets / harmonics / tracking flags after a
-        bluesky restart.
     """
-
     undulators = oregistry.find("undulators")
     energy = oregistry.find("energy")
 
-    # The flag dance below answers, for each kwarg, "did the caller
-    # supply a value, or should we prompt?"  When a sentinel matches we
-    # also seed the prompt's default with a sensible value pulled from
-    # the live device state.
-    ds_inq = False
-    us_inq = False
-    ds_off_inq = False
-    us_off_inq = False
-    if ds != "N":
-        ds_inq = True
-    elif ds == "N" and undulators.ds.tracking.get():
-        # No kwarg given but the device is already tracking → default the
-        # prompt to "yes" so the user just hits enter to keep tracking.
-        ds = "Y"
-        ds_inq = False
-    else:
-        ds_inq = False
-
-    if us != "N":
-        us_inq = True
-    elif us == "N" and undulators.us.tracking.get():
-        us = "Y"
-        us_inq = False
-    else:
-        us_inq = False
-
-    # Offset defaults: if the device's current offset is 0 (probably
-    # uninitialised) and the caller didn't pass a value, default the
-    # prompt to the *calculated* offset (mono - undulator readback).
-    # Otherwise default to the device's current offset.  When the
-    # caller supplies a value via kwarg, skip the prompt entirely.
-    if undulators.ds.energy_offset.get() == 0 and ds_off == _OFFSET_SENTINEL:
-        ds_off = undulators.ds.energy.readback.get() - energy.get()
-    elif ds_off == _OFFSET_SENTINEL:
-        ds_off = undulators.ds.energy_offset.get()
-    else:
-        ds_off_inq = True
-    if undulators.us.energy_offset.get() == 0 and us_off == _OFFSET_SENTINEL:
-        us_off = undulators.us.energy.readback.get() - energy.get()
-    elif us_off == _OFFSET_SENTINEL:
-        us_off = undulators.us.energy_offset.get()
-    else:
-        us_off_inq = True
-
-    # Harmonic defaults: pull from the device unless a kwarg was passed.
-    if ds_harm == _HARM_SENTINEL:
-        ds_harm = undulators.ds.harmonic_value.get()
-        ds_harm_inq = False
-    else:
-        ds_harm_inq = True
-
-    if us_harm == _HARM_SENTINEL:
-        us_harm = undulators.us.harmonic_value.get()
-        us_harm_inq = False
-    else:
-        us_harm_inq = True
-
-    # ----------------------------------------------------------------
-    # DS undulator  (the US branch below is byte-identical except for
-    # the side prefix — see the cleanup TODO at the end of the file).
-    # ----------------------------------------------------------------
-    ds = ds if ds_inq else input(f"Use DS undulator [{ds}]: ") or ds
-    if ds in ["Yes", "Y", "y", "yes"]:
-        ds_off = (
-            ds_off
-            if ds_off_inq
-            else input(
-                f"   DS undulator offset (value/[c]alculate) [{ds_off:.3f}]: "
-            )
-            or ds_off
-        )
-        if ds_off == "c":
-            ds_off = undulators.ds.energy.readback.get() - energy.get()
-        ds_harm = (
-            ds_harm
-            if ds_harm_inq
-            else input(
-                f"   DS undulator harmonics (1,3,5,../[c]alculate) [{ds_harm:.0f}]: "
-            )
-            or ds_harm
-        )
-        if ds_harm == "c":
-            ds_harm = _auto_harmonic(energy.get())
-
-        undulators.ds.energy_offset.put(float(ds_off))
-        undulators.ds.tracking.put(True)
-        try:
-            if ds_harm in [1, 3, 5, 7, 9]:
-                undulators.ds.harmonic_value.put(int(ds_harm))
-                print(f"Undulator uses harmonic {ds_harm:.0f}")
-            else:
-                print("     Harmonics needs to be an odd integer!")
-        except Exception:
-            print("     Undulator currently disabled")
-        print(f"DS undulator tracking with offset = {float(ds_off):.3f}\n")
-    else:
-        undulators.ds.tracking.put(False)
-        print("DS undulator tracking OFF\n")
-
-    # ----------------------------------------------------------------
-    # US undulator  (duplicate of DS branch above — see cleanup TODO).
-    # ----------------------------------------------------------------
-    us = us if us_inq else input(f"Use US undulator [{us}]: ") or us
-    if us in ["Yes", "Y", "y", "yes"]:
-        us_off = (
-            us_off
-            if us_off_inq
-            else input(
-                f"   US undulator offset (value/[c]alculate) [{us_off:.3f}]: "
-            )
-            or us_off
-        )
-        if us_off == "c":
-            us_off = undulators.us.energy.readback.get() - energy.get()
-        us_harm = (
-            us_harm
-            if us_harm_inq
-            else input(
-                f"   US undulator harmonics (1,3,5,../[c]alculate) [{us_harm:.0f}]: "
-            )
-            or us_harm
-        )
-        # NOTE: previously this branch wrote to ``ds_harm`` instead of
-        # ``us_harm`` — a copy-paste bug from the duplicated DS/US logic.
-        # Fixed here to write to the correct US variable.
-        if us_harm == "c":
-            us_harm = _auto_harmonic(energy.get())
-        undulators.us.energy_offset.put(float(us_off))
-        undulators.us.tracking.put(True)
-        try:
-            if us_harm in [1, 3, 5, 7, 9]:
-                undulators.us.harmonic_value.put(int(us_harm))
-                print(f"Undulator uses harmonic {us_harm:.0f}")
-            else:
-                print("     Harmonics needs to be an odd integer!")
-        except Exception:
-            print("     Undulator currently disabled")
-        print(f"US undulator tracking with offset = {float(us_off):.3f}")
-    else:
-        undulators.us.tracking.put(False)
-        print("US undulator tracking OFF")
+    _setup_one_side("ds", undulators, energy, ds_off, ds_harm)
+    _setup_one_side("us", undulators, energy, us_off, us_harm)
 
     # Auto-save the new offsets/deadbands so a bluesky restart can
     # re-apply them via session_state.restore_session_state().  Lazy
@@ -257,40 +199,5 @@ def undulator_setup(
         from .session_state import _save_undulator
 
         _save_undulator()
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001 — never break a setup function
         pass
-
-
-# ---------------------------------------------------------------------------
-# TODO(undulator_setup cleanup) — see the chat thread that introduced this
-# block.  Keeping the function as-is for now to avoid behaviour change in
-# the same PR as session_state; revisit as a focused refactor.
-#
-# Concrete items:
-#
-# 1. Replace the magic sentinels (999 / 0 / "N") with ``None`` so the
-#    "kwarg supplied vs not" check is just ``if value is None:``.  Drops
-#    the six ``*_inq`` flags entirely.
-#
-# 2. Extract the per-side block (lines under "DS undulator" / "US
-#    undulator" banners) into a private ``_setup_one_side(side, …)``
-#    helper called twice.  Halves the function length and removes the
-#    class of bugs that produced the harmonic copy-paste mistake just
-#    fixed in this commit.
-#
-# 3. Catch a specific exception in the harmonic ``try`` blocks instead of
-#    bare ``Exception``.  Today's ``except Exception:`` swallows real
-#    bugs along with "undulator disabled" timeouts.
-#
-# 4. Decide whether ``undulator_setup`` should still toggle each
-#    undulator's ``.tracking`` flag at all, given that
-#    ``energy.tracking_setup([...])`` is the canonical "which devices
-#    follow energy" selector.  Two paths to the same state are confusing.
-#    Likely outcome: keep the offset/harmonic prompts here, drop the
-#    on/off prompt and document that users go through
-#    ``energy.tracking_setup`` for that toggle.
-#
-# 5. Once 1–4 are done the function shrinks to ~50 lines with one
-#    docstring per public symbol; the current block-comment scaffolding
-#    (the "DS undulator" / "US undulator" banners) becomes redundant.
-# ---------------------------------------------------------------------------

--- a/src/id4_common/utils/undulator_setup.py
+++ b/src/id4_common/utils/undulator_setup.py
@@ -151,3 +151,13 @@ def undulator_setup(
     else:
         undulators.us.tracking.put(False)
         print("US undulator tracking OFF")
+
+    # Auto-save the new offsets/deadbands so a bluesky restart can
+    # re-apply them via session_state.restore_session_state().  Lazy
+    # import keeps the module-load order safe.
+    try:
+        from .session_state import _save_undulator
+
+        _save_undulator()
+    except Exception:  # noqa: BLE001
+        pass

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -56,8 +55,9 @@ def fresh_module(monkeypatch):
     return ss, devices, re_md
 
 
-def _stub_undulators(devices, *, ds_offset=0.0, ds_db=0.002, us_offset=0.0,
-                     us_db=0.002):
+def _stub_undulators(
+    devices, *, ds_offset=0.0, ds_db=0.002, us_offset=0.0, us_db=0.002
+):
     """Plant an `undulators` device with us/ds energy_offset + deadband."""
     dev = SimpleNamespace()
     for side, off, db in (("us", us_offset, us_db), ("ds", ds_offset, ds_db)):
@@ -98,8 +98,9 @@ def _stub_qxscan(devices, *, params=None):
 
 def test_save_undulator_writes_offsets_and_deadbands(fresh_module):
     ss, devices, re_md = fresh_module
-    _stub_undulators(devices, ds_offset=-0.072, ds_db=0.002,
-                     us_offset=0.0, us_db=0.001)
+    _stub_undulators(
+        devices, ds_offset=-0.072, ds_db=0.002, us_offset=0.0, us_db=0.001
+    )
 
     ss._save_undulator()
 
@@ -201,13 +202,16 @@ def test_save_session_state_calls_every_helper(fresh_module, monkeypatch):
 
     fake_pr = ModuleType("id4_common.utils.pr_setup")
     fake_pr.pr_setup = SimpleNamespace(
-        positioner=None, offset=None, oscillate_pzt=True,
+        positioner=None,
+        offset=None,
+        oscillate_pzt=True,
     )
     monkeypatch.setitem(sys.modules, "id4_common.utils.pr_setup", fake_pr)
 
     fake_c = ModuleType("id4_common.utils.counters_class")
     fake_c.counters = SimpleNamespace(
-        _selected_dets=[], _selected_mon=("scaler1", "Time"),
+        _selected_dets=[],
+        _selected_mon=("scaler1", "Time"),
         _selected_extra_read=[],
     )
     monkeypatch.setitem(sys.modules, "id4_common.utils.counters_class", fake_c)
@@ -263,36 +267,47 @@ def test_restore_pr_setup_resolves_devices(fresh_module, monkeypatch):
     )
 
     fake_pr_singleton = SimpleNamespace(
-        positioner=None, offset=None, oscillate_pzt=False,
+        positioner=None,
+        offset=None,
+        oscillate_pzt=False,
     )
     fake_pr = ModuleType("id4_common.utils.pr_setup")
     fake_pr.pr_setup = fake_pr_singleton
     monkeypatch.setitem(sys.modules, "id4_common.utils.pr_setup", fake_pr)
 
-    status = ss._restore_pr_setup({
-        "positioner": "pr2_pzt_localdc",
-        "offset": "pr2_pzt_offset_microns",
-        "oscillate_pzt": True,
-    })
+    status = ss._restore_pr_setup(
+        {
+            "positioner": "pr2_pzt_localdc",
+            "offset": "pr2_pzt_offset_microns",
+            "oscillate_pzt": True,
+        }
+    )
     assert status == "applied"
     assert fake_pr_singleton.positioner is devices["pr2_pzt_localdc"]
     assert fake_pr_singleton.offset is devices["pr2_pzt_offset_microns"]
     assert fake_pr_singleton.oscillate_pzt is True
 
 
-def test_restore_pr_setup_skips_when_positioner_unknown(fresh_module,
-                                                         monkeypatch):
+def test_restore_pr_setup_skips_when_positioner_unknown(
+    fresh_module, monkeypatch
+):
     ss, _, _ = fresh_module
 
     fake_pr = ModuleType("id4_common.utils.pr_setup")
     fake_pr.pr_setup = SimpleNamespace(
-        positioner=None, offset=None, oscillate_pzt=False,
+        positioner=None,
+        offset=None,
+        oscillate_pzt=False,
     )
     monkeypatch.setitem(sys.modules, "id4_common.utils.pr_setup", fake_pr)
 
-    status = ss._restore_pr_setup({
-        "positioner": "missing_pzt", "offset": None, "oscillate_pzt": True,
-    })
+    status = ss._restore_pr_setup(
+        {
+            "positioner": "missing_pzt",
+            "offset": None,
+            "oscillate_pzt": True,
+        }
+    )
     assert "skipped" in status
     assert "missing_pzt" in status
 

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1,0 +1,346 @@
+"""Tests for id4_common.utils.session_state (auto-saved RE.md knobs)."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fresh_module(monkeypatch):
+    """Reload session_state with a stub RE.md (plain dict) and stub
+    oregistry.
+
+    Returns ``(module, fake_oregistry, RE_md)`` so tests can populate the
+    registry, drive the save/restore helpers, and inspect what landed in
+    ``RE.md["session_state"]``.
+    """
+    sys.modules.pop("id4_common.utils.session_state", None)
+
+    # Stub RE.md as a real dict so PersistentDict semantics aren't needed.
+    re_md = {}
+    fake_re = MagicMock(name="RE")
+    fake_re.md = re_md
+    sys.modules["id4_common.utils.run_engine"].RE = fake_re
+
+    # Stub oregistry; tests fill in `_devices` to control find().
+    devices: dict = {}
+
+    def _find(name, allow_none=False, **_):
+        dev = devices.get(name)
+        if dev is None and not allow_none:
+            raise LookupError(name)
+        return dev
+
+    fake_oregistry = MagicMock()
+    fake_oregistry.find.side_effect = _find
+    monkeypatch.setattr(
+        sys.modules["apsbits.core.instrument_init"],
+        "oregistry",
+        fake_oregistry,
+    )
+
+    import id4_common.utils.session_state as ss
+
+    monkeypatch.setattr(ss, "oregistry", fake_oregistry)
+
+    return ss, devices, re_md
+
+
+def _stub_undulators(devices, *, ds_offset=0.0, ds_db=0.002, us_offset=0.0,
+                     us_db=0.002):
+    """Plant an `undulators` device with us/ds energy_offset + deadband."""
+    dev = SimpleNamespace()
+    for side, off, db in (("us", us_offset, us_db), ("ds", ds_offset, ds_db)):
+        side_dev = SimpleNamespace()
+        side_dev.energy_offset = MagicMock()
+        side_dev.energy_offset.get.return_value = off
+        side_dev.energy_deadband = MagicMock()
+        side_dev.energy_deadband.get.return_value = db
+        setattr(dev, side, side_dev)
+    devices["undulators"] = dev
+    return dev
+
+
+def _stub_energy(devices, *, tracked_names=()):
+    """Plant an `energy` device with trackable_devices reflecting flags."""
+    trackables = []
+    for name in ("undulators_us", "undulators_ds", "pr2"):
+        td = SimpleNamespace(name=name, tracking=MagicMock())
+        td.tracking.get.return_value = name in tracked_names
+        trackables.append(td)
+    energy = MagicMock()
+    energy.trackable_devices = trackables
+    devices["energy"] = energy
+    return energy
+
+
+def _stub_qxscan(devices, *, params=None):
+    qx = MagicMock()
+    qx._make_params_dict.return_value = params or {"edge": {"Estart": -10}}
+    devices["qxscan_setup"] = qx
+    return qx
+
+
+# ---------------------------------------------------------------------------
+# Save helpers
+# ---------------------------------------------------------------------------
+
+
+def test_save_undulator_writes_offsets_and_deadbands(fresh_module):
+    ss, devices, re_md = fresh_module
+    _stub_undulators(devices, ds_offset=-0.072, ds_db=0.002,
+                     us_offset=0.0, us_db=0.001)
+
+    ss._save_undulator()
+
+    snap = re_md["session_state"]["undulators"]
+    assert snap == {
+        "us": {"energy_offset": 0.0, "energy_deadband": 0.001},
+        "ds": {"energy_offset": -0.072, "energy_deadband": 0.002},
+    }
+    assert "saved_at" in re_md["session_state"]
+
+
+def test_save_undulator_skips_when_device_missing(fresh_module):
+    ss, _, re_md = fresh_module
+    ss._save_undulator()
+    assert re_md == {}
+
+
+def test_save_energy_tracking_lists_active_names(fresh_module):
+    ss, devices, re_md = fresh_module
+    _stub_energy(devices, tracked_names=("undulators_ds", "pr2"))
+
+    ss._save_energy_tracking()
+
+    assert re_md["session_state"]["energy_tracking"] == {
+        "devices": ["undulators_ds", "pr2"],
+    }
+
+
+def test_save_pr_setup_serialises_names_only(fresh_module, monkeypatch):
+    ss, _, re_md = fresh_module
+
+    fake_pr = ModuleType("id4_common.utils.pr_setup")
+    fake_pr.pr_setup = SimpleNamespace(
+        positioner=SimpleNamespace(name="pr2_pzt_localdc"),
+        offset=SimpleNamespace(name="pr2_pzt_offset_microns"),
+        oscillate_pzt=True,
+    )
+    monkeypatch.setitem(sys.modules, "id4_common.utils.pr_setup", fake_pr)
+
+    ss._save_pr_setup()
+
+    assert re_md["session_state"]["pr_setup"] == {
+        "positioner": "pr2_pzt_localdc",
+        "offset": "pr2_pzt_offset_microns",
+        "oscillate_pzt": True,
+    }
+
+
+def test_save_counters_records_dev_channel_pairs(fresh_module, monkeypatch):
+    ss, _, re_md = fresh_module
+
+    fake_c = ModuleType("id4_common.utils.counters_class")
+    fake_c.counters = SimpleNamespace(
+        _selected_dets=[("scaler1", "Mn"), ("scaler1", "Fe")],
+        _selected_mon=("scaler1", "I0"),
+        _selected_extra_read=[],
+    )
+    monkeypatch.setitem(sys.modules, "id4_common.utils.counters_class", fake_c)
+
+    ss._save_counters()
+
+    assert re_md["session_state"]["counters"] == {
+        "detectors": [["scaler1", "Mn"], ["scaler1", "Fe"]],
+        "monitor": ["scaler1", "I0"],
+        "extra_read": [],
+    }
+
+
+def test_save_qxscan_with_source_uses_pointer(fresh_module):
+    ss, devices, re_md = fresh_module
+    _stub_qxscan(devices)
+
+    ss._save_qxscan(source="tb.json")
+
+    assert re_md["session_state"]["qxscan"] == {"source": "tb.json"}
+
+
+def test_save_qxscan_without_source_inlines_params(fresh_module):
+    ss, devices, re_md = fresh_module
+    _stub_qxscan(devices, params={"edge": {"Estart": -5}})
+
+    ss._save_qxscan()
+
+    assert re_md["session_state"]["qxscan"] == {
+        "params": {"edge": {"Estart": -5}}
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public save / restore
+# ---------------------------------------------------------------------------
+
+
+def test_save_session_state_calls_every_helper(fresh_module, monkeypatch):
+    ss, devices, re_md = fresh_module
+    _stub_undulators(devices)
+    _stub_energy(devices, tracked_names=("pr2",))
+    _stub_qxscan(devices)
+
+    fake_pr = ModuleType("id4_common.utils.pr_setup")
+    fake_pr.pr_setup = SimpleNamespace(
+        positioner=None, offset=None, oscillate_pzt=True,
+    )
+    monkeypatch.setitem(sys.modules, "id4_common.utils.pr_setup", fake_pr)
+
+    fake_c = ModuleType("id4_common.utils.counters_class")
+    fake_c.counters = SimpleNamespace(
+        _selected_dets=[], _selected_mon=("scaler1", "Time"),
+        _selected_extra_read=[],
+    )
+    monkeypatch.setitem(sys.modules, "id4_common.utils.counters_class", fake_c)
+
+    snap = ss.save_session_state()
+    assert "undulators" in snap
+    assert "energy_tracking" in snap
+    assert "pr_setup" in snap
+    assert "counters" in snap
+    assert "qxscan" in snap
+
+
+def test_restore_no_snapshot_returns_skipped(fresh_module):
+    ss, _, _ = fresh_module
+    status = ss.restore_session_state()
+    assert status == {"session_state": "skipped: no snapshot in RE.md"}
+
+
+def test_restore_undulator_calls_put(fresh_module):
+    ss, devices, _ = fresh_module
+    dev = _stub_undulators(devices)
+
+    status = ss._restore_undulator(
+        {"ds": {"energy_offset": -0.072, "energy_deadband": 0.002}}
+    )
+
+    assert status == "applied"
+    dev.ds.energy_offset.put.assert_called_once_with(-0.072)
+    dev.ds.energy_deadband.put.assert_called_once_with(0.002)
+
+
+def test_restore_undulator_missing_device(fresh_module):
+    ss, _, _ = fresh_module
+    status = ss._restore_undulator({"ds": {"energy_offset": 0.0}})
+    assert status.startswith("skipped:")
+
+
+def test_restore_energy_tracking_invokes_setup(fresh_module):
+    ss, devices, _ = fresh_module
+    energy = _stub_energy(devices, tracked_names=())
+
+    status = ss._restore_energy_tracking({"devices": ["pr2"]})
+
+    assert status == "applied"
+    energy.tracking_setup.assert_called_once_with(["pr2"])
+
+
+def test_restore_pr_setup_resolves_devices(fresh_module, monkeypatch):
+    ss, devices, _ = fresh_module
+    devices["pr2_pzt_localdc"] = SimpleNamespace(name="pr2_pzt_localdc")
+    devices["pr2_pzt_offset_microns"] = SimpleNamespace(
+        name="pr2_pzt_offset_microns"
+    )
+
+    fake_pr_singleton = SimpleNamespace(
+        positioner=None, offset=None, oscillate_pzt=False,
+    )
+    fake_pr = ModuleType("id4_common.utils.pr_setup")
+    fake_pr.pr_setup = fake_pr_singleton
+    monkeypatch.setitem(sys.modules, "id4_common.utils.pr_setup", fake_pr)
+
+    status = ss._restore_pr_setup({
+        "positioner": "pr2_pzt_localdc",
+        "offset": "pr2_pzt_offset_microns",
+        "oscillate_pzt": True,
+    })
+    assert status == "applied"
+    assert fake_pr_singleton.positioner is devices["pr2_pzt_localdc"]
+    assert fake_pr_singleton.offset is devices["pr2_pzt_offset_microns"]
+    assert fake_pr_singleton.oscillate_pzt is True
+
+
+def test_restore_pr_setup_skips_when_positioner_unknown(fresh_module,
+                                                         monkeypatch):
+    ss, _, _ = fresh_module
+
+    fake_pr = ModuleType("id4_common.utils.pr_setup")
+    fake_pr.pr_setup = SimpleNamespace(
+        positioner=None, offset=None, oscillate_pzt=False,
+    )
+    monkeypatch.setitem(sys.modules, "id4_common.utils.pr_setup", fake_pr)
+
+    status = ss._restore_pr_setup({
+        "positioner": "missing_pzt", "offset": None, "oscillate_pzt": True,
+    })
+    assert "skipped" in status
+    assert "missing_pzt" in status
+
+
+def test_restore_qxscan_via_source(fresh_module):
+    ss, devices, _ = fresh_module
+    qx = _stub_qxscan(devices)
+
+    status = ss._restore_qxscan({"source": "tb.json"})
+    assert status.startswith("applied")
+    qx.load_params_json.assert_called_once_with("tb.json")
+
+
+def test_restore_qxscan_via_inline_params(fresh_module):
+    ss, devices, _ = fresh_module
+    qx = _stub_qxscan(devices)
+
+    status = ss._restore_qxscan({"params": {"edge": {"Estart": -5}}})
+    assert status.startswith("applied")
+    qx._read_params_dict.assert_called_once_with({"edge": {"Estart": -5}})
+
+
+def test_restore_qxscan_missing_source_and_params(fresh_module):
+    ss, devices, _ = fresh_module
+    _stub_qxscan(devices)
+
+    status = ss._restore_qxscan({})
+    assert "skipped" in status
+
+
+def test_restore_qxscan_failed_load_reports(fresh_module):
+    ss, devices, _ = fresh_module
+    qx = _stub_qxscan(devices)
+    qx.load_params_json.side_effect = FileNotFoundError("no.json")
+
+    status = ss._restore_qxscan({"source": "no.json"})
+    assert status.startswith("failed:")
+    assert "FileNotFoundError" in status
+
+
+def test_restore_session_state_with_explicit_state_skips_re_md(fresh_module):
+    ss, devices, re_md = fresh_module
+    re_md["session_state"] = {"qxscan": {"source": "wrong.json"}}
+    qx = _stub_qxscan(devices)
+
+    status = ss.restore_session_state(
+        state={"qxscan": {"source": "right.json"}}
+    )
+
+    assert status["qxscan"].startswith("applied")
+    qx.load_params_json.assert_called_once_with("right.json")


### PR DESCRIPTION
Closes #18.

Stacked on top of PR #62 (`centering`) → PR #61 (`multi_issues`) → main.  Base set to `centering` so the diff shows only the four commits this PR owns.  Once those land, GitHub will auto-rebase against main.

## Commit map

| Commit | Topic |
|---|---|
| `36c5e86` | New `id4_common.macros/` package — curated single-import surface + 5 example macros |
| `fae540d` | New `id4_common.utils.session_state` — auto-save knobs to `RE.md["session_state"]`; `restore_session_state()` re-applies after restart |
| `84cdd41` | `undulator_setup`: documentation, named constants, fix US-harmonic copy-paste typo (no behaviour change) |
| `db4bd9a` | `undulator_setup`: refactor — kill sentinels, extract `_setup_one_side`, drop on/off prompt |

---

## #18 (a) — Single curated import surface

User pain: production macros open with 11 import lines (real example, `Tb_Pedro_26-1/macros.py`):

```python
from bluesky.plan_stubs import move_per_step, abs_set, trigger_and_read, rd, sleep
from apsbits.core.instrument_init import oregistry
from id4_common.plans.local_scans import grid_scan, mv, mvr, rel_grid_scan, ascan, lup, qxscan
from id4_common.utils.run_engine import RE, peaks
from id4_common.utils.attenuator_utils import atten
from id4_common.plans.center_maximum import cen, maxi
from id4_common.utils.counters_class import counters
from pathlib import Path
import numpy as np
from epics import caput, caget
from bluesky.plan_stubs import sleep            # accidental duplicate
# from id4_common.utils.hkl_utils import br, ubr   # commented — module renamed
```

Plus the brittle reality that the next time someone reorgs the package (e.g. PR #56 splitting `local_scans.py`), the import breaks silently.

Solution — `from id4_common.macros.macros_api import *`.  One curated star-import that keeps macros stable across internal reorgs.  IDE-friendly (Pylance walks `__all__`).  `bluesky.plan_stubs` helpers are *not* re-exported (per user preference), so the bluesky surface stays explicit.

Five example macros land at `docs/source/examples/macros/`, modeled on real production patterns: `align_routine.py`, `xmcd_at_two_edges.py`, `field_sequence.py`, `qxscan_chain.py`, `hkl_map.py`.

## #18 (b) — Recoverable session state (auto-save → `RE.md["session_state"]`)

User pain: after a bluesky restart, the per-experiment knobs (undulator offsets / deadbands, energy tracking selection, `pr_setup`, `counters.plotselect`, qxscan setup) all reset to defaults.  Today the user re-runs them by hand from a startup script with hardcoded values — fragile because the values drift.

Solution — auto-save into the apsbits `RE.md` PersistentDict on every setup-helper call:

| Auto-save hook lives in | Triggers when |
|---|---|
| `utils/pr_setup.py` (property setters on `positioner` / `offset` / `oscillate_pzt`) | direct attr writes (the pattern user startup files use) **and** the interactive `pr_setup()` |
| `utils/counters_class.py:CountersClass.plotselect` | every `counters.plotselect(...)` call |
| `utils/undulator_setup.py` | every `undulator_setup(...)` call |
| `devices/energy_device.py:EnergySignal.tracking_setup` | both interactive prompt and the explicit-list path |
| `devices/qxscan_device.py:QxscanParams.__call__` | interactive setup |
| `devices/qxscan_device.py:QxscanParams.load_params_json` | json reload |

Storage layout:

```python
RE.md["session_state"] = {
    "saved_at":       "2026-05-09T18:42:11",
    "undulators":     {"us": {energy_offset, energy_deadband},
                       "ds": {energy_offset, energy_deadband}},
    "energy_tracking":{"devices": ["undulators_ds", "pr2"]},
    "pr_setup":       {"positioner", "offset", "oscillate_pzt"},
    "counters":       {"detectors", "monitor", "extra_read"},   # by (dev, channel)
    "qxscan":         {"source": "tb.json"} or {"params": {...}},
}
```

Devices stored by registry name (msgpack-safe).  Counters store by `(device, channel)` pairs (matching `_selected_dets` internals) so a saved selection survives device-load-order changes.

Public API (just two functions):

```python
from id4_common.utils.session_state import restore_session_state, save_session_state

status = restore_session_state()  # called from startup macro
save_session_state()              # escape hatch
```

`restore_session_state` returns `{knob_group: status_str}` so callers can print a summary; never raises (missing device → `"skipped: …"`, failed put → `"failed: <Exception>"`, rest of restore continues).

A new example startup template at `docs/source/examples/macros/startup.py` shows the recoverable pattern:

```python
from id4_common.macros.macros_api import *
from id4_common.utils.session_state import restore_session_state
from id4_common.utils.experiment_utils import experiment_load_from_bluesky

experiment_load_from_bluesky()
status = restore_session_state()
for knob, msg in status.items():
    print(f"  {knob:18}  {msg}")
```

## #18 (c) — `undulator_setup` cleanup

While doing the session_state hooks I had to read `undulator_setup` carefully and noticed it was 154 lines of duplicated code with magic sentinels and a copy-paste bug.  Two commits:

**`84cdd41`** — pure documentation + bug fix (no behaviour change):

- Module + numpydoc docstring covering the legacy sentinel-kwarg API
- Named the magic numbers (`HARMONIC_BREAKPOINTS_KEV = ((8.6, 1), (18.0, 3))`) plus an `_auto_harmonic(energy_keV)` helper used in two places
- Block-comment banners marking the duplicated DS / US branches
- **Bug fix**: the US `harm == "c"` branch wrote to `ds_harm` instead of `us_harm` (copy-paste from the duplicated DS branch).  Now writes to the correct variable.

**`db4bd9a`** — the refactor (small public-API change):

- Sentinels (`999` / `0` / `"N"`) → `None`.  Six `*_inq` flags collapse to `if value is None: value = input(...)`.
- Per-side helper: 86-line DS branch + 86-line US branch (byte-identical) → one `_setup_one_side(side, undulators, energy, off, harm)` called twice.  Plus `_resolve_offset` / `_resolve_harmonic` helpers that each handle one prompt's full logic.
- `except Exception` → `except TimeoutError`.  After the refactor `*_harm` is always `int` by the time we `.put()`, so the only remaining failure mode is a disconnected PV.
- **Dropped the on/off prompt.**  The function used to ask "Use DS undulator?" and toggle `side.tracking.put(True/False)`.  Two paths to the same state are confusing — the canonical "which devices follow energy" toggle is `energy.tracking_setup([names])`.  The refactored function configures offset + harmonic only.

API change (worth flagging):

```python
# Before
undulator_setup(ds="Y", ds_off=-0.072, ds_harm=3, us="N")

# After
undulator_setup(ds_off=-0.072, ds_harm=3)
energy.tracking_setup(["undulators_ds"])   # explicit toggle
```

Verified safe: `grep -rn 'undulator_setup('` finds no in-repo callers (only the `_common_startup.py` import — no call), and `restore_session_state()` already calls `energy.tracking_setup` separately.

---

## Verification

- `pre-commit run --all-files`: clean across all four commits.
- `pytest tests/`: **53/53 pass** (18 existing + 6 temperature_setup + 10 peak_position + 19 new session_state).
- New `tests/test_session_state.py` (19 cases): per-knob save round-trip, restore-from-stub-RE.md, missing-device skip, failing-put failure path, partial state, explicit-state arg bypass, escape-hatch coverage.
- Static-only smoke: every example macro under `docs/source/examples/macros/` `py_compile`s cleanly; `from id4_common.macros.macros_api import *` resolves on a real beamline env (the dev box is missing `dm` so the full runtime import is verified by the test conftest stubs only).

## Things to verify at the beamline

- **macros_api**: open `docs/source/examples/macros/align_routine.py` in VS Code with Pylance — every name resolves green; introduce a typo (`lupp(...)`) and confirm the IDE flags it.
- **session_state round trip**: hand-set `pr_setup`, `energy.tracking_setup([...])`, `counters.plotselect(...)`, `undulator_setup(...)`, `qxscan_setup.load_params_json(...)`.  After each, `print(RE.md["session_state"])` should show the just-saved sub-key with a fresh `saved_at`.  Restart bluesky, run `docs/source/examples/macros/startup.py`, confirm the per-knob status dict reports `applied` for each.
- **`undulator_setup` refactor**: confirm the dropped on/off prompt isn't load-bearing for any beamline workflow (the typical pattern is `undulator_setup(...)` to set offsets + `energy.tracking_setup([...])` to toggle tracking — both paths covered by the refactored API).

## Out of scope (deferred)

1. **Per-experiment vs global state.** `RE.md` is per-`MD_PATH`, so restore picks up "the last save by anyone".  For the typical "restart bluesky inside the same experiment" workflow this is the right behaviour; per-experiment state would mean piggybacking on `.polar_experiment.yml` instead.
2. **Vortex electronics choice** (`load_vortex("xspress4")`) — orthogonal: device lifecycle, not just attribute assignment.  Stays in the user's hand-written part of the startup macro.
3. **Auto-shutter** — explicitly dropped per the user's note during planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)